### PR TITLE
Ensure org name is used in submodule relative paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "common"]
 	path = common
-	url = ../cc-common.git
+	url = ../../caida/cc-common.git
 [submodule "lib/formats/libparsebgp"]
 	path = lib/formats/libparsebgp
-	url = ../libparsebgp.git
+	url = ../../caida/libparsebgp.git


### PR DESCRIPTION
Otherwise a forked repo (which will be in a different org) will not be able to find the submodules.

Thanks to @digizeph for reporting this bug.