### PR TITLE
Fix prefix filter bug

### DIFF
--- a/lib/utils/bgpstream_utils_patricia.c
+++ b/lib/utils/bgpstream_utils_patricia.c
@@ -186,9 +186,7 @@ bgpstream_patricia_node_create(bgpstream_patricia_tree_t *pt,
     pt->ipv6_active_nodes++;
   }
 
-  node->prefix.mask_len = pfx->mask_len;
-  bgpstream_addr_copy((bgpstream_ip_addr_t *)&node->prefix.address,
-                      (bgpstream_ip_addr_t *)&pfx->address);
+  bgpstream_pfx_copy((bgpstream_pfx_t*)&node->prefix, pfx);
 
   node->parent = NULL;
   node->bit = pfx->mask_len;


### PR DESCRIPTION
The patricia tree code was doing a manual copy of the prefix when creating a new node, this meant that the new "allowed_matches" field of the prefix was not copied, and as such all pefix filters were treated as "ANY" filters (rather than MORE/EXACT/LESS). This commit changes the patricia tree to use the prefix copy method.