### PR TITLE
RPKI Prefix Origin Validation Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -258,6 +258,27 @@ if test "x$with_di_csvfile" == xyes; then
    BS_DI_OPT(csvfile-csv-file, CSVFILE_CSV_FILE, CSV file listing the MRT data to read, not-set)
 fi
 
+# RPKI configuration (ROAFetchLib)
+AC_MSG_NOTICE([])
+AC_MSG_NOTICE([---- RPKI support configuration ----])
+AC_ARG_WITH([rpki],
+        [AS_HELP_STRING([--without-rpki],
+        [do not compile with rpki support])],
+        [],
+        [with_rpki=yes])
+AM_CONDITIONAL([WITH_RPKI], [test "x$with_rpki" != xno])
+if test x"$with_rpki" = xyes; then
+    AC_CHECK_LIB([roafetch], [rpki_set_config],,
+         [AC_MSG_ERROR(
+            [ROAFetchlib is required (--without-rpki to disable)]
+    )])
+    AC_DEFINE([WITH_RPKI],[1],[Building with RPKI support])
+    AC_DEFINE([RPKI_BROKER],["http://roa-broker.realmv6.org/broker?"],[RPKI broker])
+else
+  AC_MSG_CHECKING([whether to build with RPKI support])
+  AC_MSG_RESULT([no])
+fi
+
 AC_HEADER_ASSERT
 
 AC_CONFIG_FILES([Makefile

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -332,6 +332,8 @@ char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
 
 #ifdef WITH_RPKI
     /* RPKI validation */
+    /* If the RPKI parameter was set, the corresponding input was valid and the 
+       configure was completely set up -> the elem can be validated by RPKI */
     if(elem->annotations.rpki_active){
       char result[B_REMAIN];
       if(bgpstream_rpki_validate(elem, result, sizeof(result))){

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -28,6 +28,9 @@
 #include "bgpstream_log.h"
 #include "bgpstream_record.h"
 #include "bgpstream_utils.h"
+#ifdef WITH_RPKI
+#include "bgpstream_utils_rpki.h"
+#endif
 #include "config.h"
 #include "utils.h"
 #include <assert.h>
@@ -326,6 +329,18 @@ char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
     /* NEW STATE (empty) */
     if (B_FULL)
       return NULL;
+
+#ifdef WITH_RPKI
+    /* RPKI validation */
+    if(elem->annotations.rpki_active){
+      char result[B_REMAIN];
+      if(bgpstream_rpki_validate(elem, result, sizeof(result))){
+        c = snprintf(buf_p, B_REMAIN, "%s", result);
+        written += c;
+        buf_p += c;
+      }
+    }
+#endif
 
     /* END OF LINE */
     break;

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -28,10 +28,10 @@
 #include "bgpstream_log.h"
 #include "bgpstream_record.h"
 #include "bgpstream_utils.h"
+#include "config.h"
 #ifdef WITH_RPKI
 #include "bgpstream_utils_rpki.h"
 #endif
-#include "config.h"
 #include "utils.h"
 #include <assert.h>
 #include <inttypes.h>

--- a/lib/bgpstream_elem.h
+++ b/lib/bgpstream_elem.h
@@ -27,6 +27,10 @@
 #ifndef __BGPSTREAM_ELEM_H
 #define __BGPSTREAM_ELEM_H
 
+#include "config.h"
+#ifdef WITH_RPKI
+#include <roafetchlib/roafetchlib.h>
+#endif
 #include "bgpstream_utils.h"
 
 /** @file
@@ -107,6 +111,21 @@ typedef enum {
 
 } bgpstream_elem_type_t;
 
+typedef struct struct_bgpstream_annotations_t {
+  
+#ifdef WITH_RPKI
+  /** RPKI active */
+  int rpki_active;
+
+  /** RPKI validation configuration */
+  rpki_cfg_t* cfg;
+
+  /** Record timestamp */
+  uint32_t timestamp;
+#endif
+
+} bgpstream_annotations_t;
+
 /** @} */
 
 /**
@@ -186,6 +205,12 @@ typedef struct bgpstream_elem {
    * Available only for the Peer-state elem type
    */
   bgpstream_elem_peerstate_t new_state;
+
+  /** Annotations
+   *
+   * Annotations from other libraries
+   */
+  bgpstream_annotations_t annotations;
 
 } bgpstream_elem_t;
 

--- a/lib/bgpstream_elem.h
+++ b/lib/bgpstream_elem.h
@@ -27,10 +27,6 @@
 #ifndef __BGPSTREAM_ELEM_H
 #define __BGPSTREAM_ELEM_H
 
-#include "config.h"
-#ifdef WITH_RPKI
-#include <roafetchlib/roafetchlib.h>
-#endif
 #include "bgpstream_utils.h"
 
 /** @file
@@ -113,16 +109,14 @@ typedef enum {
 
 typedef struct struct_bgpstream_annotations_t {
   
-#ifdef WITH_RPKI
   /** RPKI active */
   int rpki_active;
 
   /** RPKI validation configuration */
-  rpki_cfg_t* cfg;
+  struct struct_rpki_config_t *cfg;
 
   /** Record timestamp */
   uint32_t timestamp;
-#endif
 
 } bgpstream_annotations_t;
 

--- a/lib/utils/Makefile.am
+++ b/lib/utils/Makefile.am
@@ -48,6 +48,7 @@ include_HEADERS= bgpstream_utils.h 		     \
 		 bgpstream_utils_str_set.h	     \
 		 bgpstream_utils_ip_counter.h	     \
 	         bgpstream_utils_patricia.h  \
+	   bgpstream_utils_rpki.h  \
 		 bgpstream_utils_time.h
 
 
@@ -79,6 +80,8 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_ip_counter.h	    \
 	bgpstream_utils_patricia.c	    \
 	bgpstream_utils_patricia.h		\
+	bgpstream_utils_rpki.c	    \
+	bgpstream_utils_rpki.h	    \
 	bgpstream_utils_time.c    \
 	bgpstream_utils_time.h
 

--- a/lib/utils/Makefile.am
+++ b/lib/utils/Makefile.am
@@ -35,6 +35,15 @@ noinst_LTLIBRARIES = libbgpstream-utils.la
 
 CONDITIONAL_LIBS=
 
+# Compile RPKI files only if WITH_RPKI is set
+if WITH_RPKI
+RPKI_SRCS=bgpstream_utils_rpki.c bgpstream_utils_rpki.h
+RPKI_HDRS=bgpstream_utils_rpki.h
+else
+RPKI_SRCS=
+RPKI_HDRS=
+endif
+
 include_HEADERS= bgpstream_utils.h 		     \
 		 bgpstream_utils_addr.h 	     \
 		 bgpstream_utils_addr_set.h	     \
@@ -48,8 +57,8 @@ include_HEADERS= bgpstream_utils.h 		     \
 		 bgpstream_utils_str_set.h	     \
 		 bgpstream_utils_ip_counter.h	     \
 	         bgpstream_utils_patricia.h  \
-	   bgpstream_utils_rpki.h  \
-		 bgpstream_utils_time.h
+		 bgpstream_utils_time.h  \
+		 $(RPKI_HDRS)
 
 
 libbgpstream_utils_la_SOURCES =             \
@@ -80,10 +89,9 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_ip_counter.h	    \
 	bgpstream_utils_patricia.c	    \
 	bgpstream_utils_patricia.h		\
-	bgpstream_utils_rpki.c	    \
-	bgpstream_utils_rpki.h	    \
 	bgpstream_utils_time.c    \
-	bgpstream_utils_time.h
+	bgpstream_utils_time.h    \
+	$(RPKI_SRCS)
 
 
 libbgpstream_utils_la_LIBADD = $(CONDITIONAL_LIBS)

--- a/lib/utils/bgpstream_utils_rpki.c
+++ b/lib/utils/bgpstream_utils_rpki.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2014 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors:
+ *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "config.h"
+#include "bgpstream_utils.h"
+#include "bgpstream_constants.h"
+#include "bgpstream_utils_rpki.h"
+
+#define MIN_OPT_CNT 4
+#define MIN_SSH_CNT 7
+
+#ifdef WITH_RPKI
+
+bgpstream_rpki_input_t *bgpstream_rpki_create_input() {
+
+  /* Create input */
+  bgpstream_rpki_input_t *input = NULL;
+  size_t input_size = sizeof(bgpstream_rpki_input_t);
+  if ((input = (bgpstream_rpki_input_t *)malloc(input_size)) == NULL) {
+    return NULL;
+  } else {
+    memset(input, 0, input_size);
+  }
+
+  /* Initializing all members */
+  memset(input->rpki_projects, 0, sizeof(input->rpki_projects));
+  memset(input->rpki_collectors, 0, sizeof(input->rpki_collectors));
+  memset(input->rpki_ssh_arg, 0, sizeof(input->rpki_ssh_arg));
+  memset(input->rpki_windows, 0, sizeof(input->rpki_windows));
+  input->rpki_historical = 0;
+  input->rpki_unified = 0;
+  input->rpki_ssh = 0;
+  input->rpki_options_cnt = 0;
+  input->rpki_active = 0;
+  input->rpki_ptr = NULL;
+  input->rpki_check = NULL;
+
+  return input;
+}
+
+void bgpstream_rpki_destroy_input(bgpstream_rpki_input_t *input) {
+
+  /* Destroy input if necessary */
+  if (input == NULL) {
+    return;
+  }
+  free(input);
+}
+
+bgpstream_rpki_input_t *bgpstream_rpki_parse_input(char *optarg) {
+
+  /* Create input */
+  bgpstream_rpki_input_t *inp = bgpstream_rpki_create_input();
+
+  char* optarg_dup = strdup(optarg);
+
+  /* Check if enough RPKI arguments are present before parsing */
+  int count_options = 0;
+  const char *tmp = optarg_dup;
+  while(tmp = strstr(tmp, ",")) { count_options++; tmp++; }
+  if(count_options < MIN_OPT_CNT) {
+    fprintf(stderr, "ERROR:  Invalid RPKI options\n");
+    fprintf(stderr, " * FORMAT: historical,unified,ssh,project,collector\n");
+    inp->rpki_args_check = 0;
+    return inp;
+  }
+
+
+  /* Parse all binary based input arguments */
+  inp->rpki_historical =
+      strtol(inp->rpki_check = strtok(optarg, ","), &(inp->rpki_ptr), 10);
+  inp->rpki_historical =
+      (inp->rpki_ptr == inp->rpki_check ? -1 : inp->rpki_historical);
+  inp->rpki_unified =
+      strtol(inp->rpki_check = strtok(NULL, ","), &(inp->rpki_ptr), 10);
+  inp->rpki_unified =
+      (inp->rpki_ptr == inp->rpki_check ? -1 : inp->rpki_unified);
+  inp->rpki_ssh =
+      strtol(inp->rpki_check = strtok(NULL, ","), &(inp->rpki_ptr), 10);
+  inp->rpki_ssh = (inp->rpki_ptr == inp->rpki_check ? -1 : inp->rpki_ssh);
+
+  /* Check if all necessary arguments are valid */
+  if ((inp->rpki_historical != 0 && inp->rpki_historical != 1) ||
+      (inp->rpki_unified != 0 && inp->rpki_unified != 1) ||
+      (inp->rpki_ssh != 0 && inp->rpki_ssh != 1)) {
+    fprintf(stderr, "ERROR: Invalid RPKI options\n");
+    inp->rpki_args_check = 0;
+    return inp;
+  }
+  
+  /* Check if enough SSH arguments are present before parsing */
+  if(inp->rpki_ssh == 1) {
+    int count_ssh_options = 0;
+    tmp = optarg_dup;
+    while(tmp = strstr(tmp, ",")) { count_ssh_options++; tmp++; }
+    if(count_ssh_options < MIN_SSH_CNT) {
+      fprintf(stderr, "ERROR:  Invalid RPKI SSH options\n");
+      fprintf(stderr, " * FORMAT: user,hostkey,private_key,project,collector\n");
+      inp->rpki_args_check = 0;
+      return inp;
+    }
+    free(optarg_dup);
+  }
+
+  /* Parse all SSH related input arguments */
+  if (inp->rpki_ssh && !(inp->rpki_historical)) {
+    for (int i = 0; i < RPKI_SSH_CNT; i++) {
+      strncat(inp->rpki_ssh_arg, !strlen(inp->rpki_ssh_arg) ? "" : ",",
+              sizeof(inp->rpki_ssh_arg) - 1);
+      strncat(inp->rpki_ssh_arg, strtok(NULL, ","),
+              sizeof(inp->rpki_ssh_arg) - 1);
+    }
+  }
+
+  /* Parse all project and collector arguments */
+  while ((inp->rpki_ptr = strtok(NULL, ",")) != NULL) {
+    if ((inp->rpki_options_cnt)++ % 2) {
+      strncat(inp->rpki_collectors, !strlen(inp->rpki_collectors) ? "" : ",",
+              sizeof(inp->rpki_collectors) - 1);
+      strncat(inp->rpki_collectors, inp->rpki_ptr, RPKI_CMD_CNT - 1);
+    } else {
+      strncat(inp->rpki_projects, !strlen(inp->rpki_projects) ? "" : ",",
+              sizeof(inp->rpki_projects) - 1);
+      strncat(inp->rpki_projects, inp->rpki_ptr, RPKI_CMD_CNT - 1);
+    }
+  }
+
+  inp->rpki_active = 1;
+  inp->rpki_args_check = 1;
+
+  return inp;
+}
+
+bgpstream_rpki_input_t *
+bgpstream_rpki_parse_windows(bgpstream_rpki_input_t *input,
+                             rpki_window_t windows[WINDOW_CMD_CNT],
+                             int windows_cnt) {
+
+  /* Parse all BGPReader window arguments */
+  char rpki_window[RPKI_WINDOW_LEN];
+  for (int i = 0; i < windows_cnt; i++) {
+    snprintf(rpki_window, sizeof(rpki_window), "%" PRIu32 "-%" PRIu32 ",",
+             windows[i].start, windows[i].end);
+    strcat(input->rpki_windows, rpki_window);
+  }
+  input->rpki_windows[strlen(input->rpki_windows) - 1] = '\0';
+
+  return input;
+}
+
+rpki_cfg_t *bgpstream_rpki_set_cfg(bgpstream_rpki_input_t *inp) {
+
+  /* Set up the ROAFetchlib configuration */
+  rpki_cfg_t *cfg = NULL;
+
+  return rpki_set_config(
+      inp->rpki_projects, inp->rpki_collectors, inp->rpki_windows,
+      inp->rpki_unified, inp->rpki_historical, RPKI_BROKER,
+      (inp->rpki_ssh && !inp->rpki_historical) ? inp->rpki_ssh_arg : NULL);
+}
+
+int bgpstream_rpki_validate(bgpstream_elem_t const *elem, char *result,
+                            size_t size) {
+
+  /* Validate a BGP elem with the ROAFetchlib */
+  int val_rst = 0;
+  char prefix[INET6_ADDRSTRLEN];
+  bgpstream_addr_ntop(prefix, INET6_ADDRSTRLEN,
+                      &(((bgpstream_pfx_t *)&(elem->prefix))->address));
+  uint32_t asn = 0;
+
+  if (!bgpstream_as_path_get_origin_val(elem->as_path, &asn)) {
+    if (!rpki_validate(elem->annotations.cfg, elem->annotations.timestamp, asn,
+                       prefix, elem->prefix.mask_len, result, size)) {
+      val_rst = 1;
+    }
+  }
+
+  return val_rst;
+}
+
+#endif

--- a/lib/utils/bgpstream_utils_rpki.c
+++ b/lib/utils/bgpstream_utils_rpki.c
@@ -178,7 +178,7 @@ void bgpstream_rpki_destroy_cfg(rpki_cfg_t *cfg) {
   if (cfg == NULL) {
     return;
   }
-  cfg_destroy(cfg);
+  rpki_destroy_config(cfg);
 }
 
 rpki_cfg_t *bgpstream_rpki_set_cfg(bgpstream_rpki_input_t *inp) {

--- a/lib/utils/bgpstream_utils_rpki.h
+++ b/lib/utils/bgpstream_utils_rpki.h
@@ -31,9 +31,8 @@
 #define __BGPSTREAM_UTILS_RPKI_H
 
 #include <stdint.h>
-#include <inttypes.h>
 #include <roafetchlib/roafetchlib.h>
-#include "bgpstream_elem_int.h"
+#include "bgpstream_elem.h"
 
 // Note the copy of the BGPStream - Window Command Count !!
 #define WINDOW_CMD_CNT 1024

--- a/lib/utils/bgpstream_utils_rpki.h
+++ b/lib/utils/bgpstream_utils_rpki.h
@@ -30,11 +30,10 @@
 #ifndef __BGPSTREAM_UTILS_RPKI_H
 #define __BGPSTREAM_UTILS_RPKI_H
 
-#ifdef WITH_RPKI
-#include "bgpstream_elem_int.h"
+#include <stdint.h>
 #include <inttypes.h>
 #include <roafetchlib/roafetchlib.h>
-#include <stdint.h>
+#include "bgpstream_elem_int.h"
 
 // Note the copy of the BGPStream - Window Command Count !!
 #define WINDOW_CMD_CNT 1024
@@ -161,6 +160,12 @@ bgpstream_rpki_parse_windows(bgpstream_rpki_input_t *input,
                              rpki_window_t windows[WINDOW_CMD_CNT],
                              int windows_cnt);
 
+/** Destroy the ROAFetchlib configuration
+ *
+ * @param cfg             Pointer to the ROAFetchlib configuration
+ */
+void bgpstream_rpki_destroy_cfg(rpki_cfg_t *cfg);
+
 /** Set up the ROAFetchlib configuration
  *
  * @param input           Pointer to the BGPStream RPKI input struct
@@ -179,5 +184,4 @@ rpki_cfg_t *bgpstream_rpki_set_cfg(bgpstream_rpki_input_t *input);
 int bgpstream_rpki_validate(bgpstream_elem_t const *elem, char *result,
                             size_t size);
 
-#endif
 #endif /* __BGPSTREAM_UTILS_H */

--- a/lib/utils/bgpstream_utils_rpki.h
+++ b/lib/utils/bgpstream_utils_rpki.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2014 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors:
+ *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
+ */
+
+#ifndef __BGPSTREAM_UTILS_RPKI_H
+#define __BGPSTREAM_UTILS_RPKI_H
+
+#ifdef WITH_RPKI
+#include "bgpstream_elem_int.h"
+#include <inttypes.h>
+#include <roafetchlib/roafetchlib.h>
+#include <stdint.h>
+
+// Note the copy of the BGPStream - Window Command Count !!
+#define WINDOW_CMD_CNT 1024
+
+#define RPKI_CMD_CNT 2048
+#define RPKI_SSH_BUFLEN 2048
+#define RPKI_WINDOW_LEN 24
+#define RPKI_SSH_CNT 3
+
+/** A BGPStream RPKI Window object */
+typedef struct rpki_window {
+  uint32_t start;
+  uint32_t end;
+} rpki_window_t;
+
+/** A BGPStream RPKI Input object */
+typedef struct bgpstream_rpki_input {
+
+  /** RPKI projects
+   *
+   * RPKI projects
+   */
+  char rpki_projects[RPKI_CMD_CNT];
+
+  /** RPKI collectors
+   *
+   * RPKI collectors
+   */
+  char rpki_collectors[RPKI_CMD_CNT];
+
+  /** RPKI arguments
+   *
+   * RPKI arguments to connect to a cache server via SSH
+   */
+  char rpki_ssh_arg[RPKI_SSH_BUFLEN];
+
+  /** RPKI windows
+   *
+   * RPKI time interval windows for the validation
+   */
+  char rpki_windows[WINDOW_CMD_CNT * RPKI_WINDOW_LEN];
+
+  /** RPKI historical
+   *
+   * Mode of the validation - live(0) or historical(1)
+   */
+  int rpki_historical;
+
+  /** RPKI unified
+   *
+   * Whether the validation is distinct(0) or unified(1)
+   */
+  int rpki_unified;
+
+  /** RPKI SSH
+   *
+   * Whether the connection is ssh-based(1) or not(0)
+   */
+  int rpki_ssh;
+
+  /** RPKI validation status
+   *
+   * Number of RPKI-related arguments
+   */
+  int rpki_options_cnt;
+
+  /** RPKI active
+   *
+   * If the RPKI support is active
+   */
+  int rpki_active;
+
+  /** RPKI parse pointer
+   *
+   * Temporarily RPKI parse pointer
+   */
+  char *rpki_ptr;
+
+  /** RPKI check
+   *
+   * Checks whether all binary-based arguments are valid
+   */
+  char *rpki_check;
+
+  /** RPKI args check
+   *
+   * Checks whether all RPKI-based arguments are valid
+   */
+  int rpki_args_check;
+
+} bgpstream_rpki_input_t;
+
+
+/** Public Functions */
+
+/** Create a BGPStream RPKI input struct instance
+ *
+ * @return                Pointer to the BGPStream RPKI input struct
+ */
+bgpstream_rpki_input_t *bgpstream_rpki_create_input();
+
+/** Destroy a BGPStream RPKI input struct instance
+ *
+ * @param input           Pointer to the BGPStream RPKI input struct
+ */
+void bgpstream_rpki_destroy_input(bgpstream_rpki_input_t *input);
+
+/** Parse all RPKI-related input arguments
+ *
+ * @param optarg          Pointer to the arguments buffer
+ * @return                Pointer to the BGPStream RPKI input struct
+ */
+bgpstream_rpki_input_t *bgpstream_rpki_parse_input(char *optarg);
+
+/** Parse all BGPStream RPKI window arguments
+ *
+ * @param input           Pointer to the BGPStream RPKI input struct
+ * @param windows         Array of structs of type rpki_window_t
+ * @param windows_cnt     Number of BGPStream RPKI interval windows
+ * @return                Pointer to the BGPStream RPKI input struct
+ */
+bgpstream_rpki_input_t *
+bgpstream_rpki_parse_windows(bgpstream_rpki_input_t *input,
+                             rpki_window_t windows[WINDOW_CMD_CNT],
+                             int windows_cnt);
+
+/** Set up the ROAFetchlib configuration
+ *
+ * @param input           Pointer to the BGPStream RPKI input struct
+ * @return                Pointer to the ROAFetchlib configuration
+ */
+rpki_cfg_t *bgpstream_rpki_set_cfg(bgpstream_rpki_input_t *input);
+
+/** Validate a BGP elem with the ROAFetchlib if the Annoucement contains an
+ * unique origin AS
+ *
+ * @param elem            Pointer to a BGPStream Elem instance
+ * @param result          Pointer to buffer for the validation result
+ * @param size            Size of the validation result buffer
+ * @return                1 if the validation process was valid - 0 otherwise
+ */
+int bgpstream_rpki_validate(bgpstream_elem_t const *elem, char *result,
+                            size_t size);
+
+#endif
+#endif /* __BGPSTREAM_UTILS_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,21 +29,28 @@ AM_CPPFLAGS = 	-I$(top_srcdir) \
 	 	-I$(top_srcdir)/lib/utils \
 	 	-I$(top_srcdir)/common
 
+# Run bgpstream-test-rpki only if WITH_RPKI is set
+if WITH_RPKI
+RPKI_TEST=bgpstream-test-rpki
+else
+RPKI_TEST=
+endif
+
 TESTS = 				\
 	bgpstream-test 			\
 	bgpstream-test-filters		\
 	bgpstream-test-utils-addr 	\
 	bgpstream-test-utils-pfx	\
-	bgpstream-test-utils-patricia	\
-	bgpstream-test-rpki
+	bgpstream-test-utils-patricia 			\
+  $(RPKI_TEST)
 
 check_PROGRAMS =  			\
 	bgpstream-test 			\
 	bgpstream-test-filters		\
-	bgpstream-test-rpki 			\
 	bgpstream-test-utils-addr 	\
 	bgpstream-test-utils-pfx	\
-	bgpstream-test-utils-patricia
+	bgpstream-test-utils-patricia  \
+  $(RPKI_TEST)
 
 bgpstream_test_SOURCES = bgpstream-test.c bgpstream_test.h
 bgpstream_test_LDADD   = $(top_builddir)/lib/libbgpstream.la

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -34,11 +34,13 @@ TESTS = 				\
 	bgpstream-test-filters		\
 	bgpstream-test-utils-addr 	\
 	bgpstream-test-utils-pfx	\
-	bgpstream-test-utils-patricia
+	bgpstream-test-utils-patricia	\
+	bgpstream-test-rpki
 
 check_PROGRAMS =  			\
 	bgpstream-test 			\
 	bgpstream-test-filters		\
+	bgpstream-test-rpki 			\
 	bgpstream-test-utils-addr 	\
 	bgpstream-test-utils-pfx	\
 	bgpstream-test-utils-patricia
@@ -48,6 +50,9 @@ bgpstream_test_LDADD   = $(top_builddir)/lib/libbgpstream.la
 
 bgpstream_test_filters_SOURCES = bgpstream-test-filters.c bgpstream_test.h
 bgpstream_test_filters_LDADD   = $(top_builddir)/lib/libbgpstream.la
+
+bgpstream_test_rpki_SOURCES = bgpstream-test-rpki.c bgpstream_test.h
+bgpstream_test_rpki_LDADD   = $(top_builddir)/lib/libbgpstream.la
 
 bgpstream_test_utils_addr_SOURCES = bgpstream-test-utils-addr.c bgpstream_test.h
 bgpstream_test_utils_addr_LDADD   = $(top_builddir)/lib/libbgpstream.la

--- a/test/bgpstream-test-rpki.c
+++ b/test/bgpstream-test-rpki.c
@@ -27,12 +27,12 @@
  *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
  */
 
+#include <stdio.h>
+#include <string.h>
+#include "utils.h"
 #include "bgpstream-test-rpki.h"
 #include "bgpstream_test.h"
 #include "bgpstream_utils_rpki.h"
-#include "utils.h"
-#include <stdio.h>
-#include <string.h>
 
 bgpstream_t *bs;
 bgpstream_data_interface_id_t di_id = 0;
@@ -45,13 +45,13 @@ static int val_compare(const void *cmp1, const void *cmp2) {
 
 void sort(char *buf[], int n) {
 
-  /* Sort the  validation results */
+  /* Sort the validation results */
   qsort(buf, n, sizeof(const char *), val_compare);
 }
 
 int split_result(char *val_result, char **val_result_buf) {
 
-  /* Split the validation result into an string array */
+  /* Split the validation result into a string array */
   int cnt = 0;
   val_result_buf[cnt] = strtok(val_result, ";");
   while (val_result_buf[cnt] != NULL) {

--- a/test/bgpstream-test-rpki.c
+++ b/test/bgpstream-test-rpki.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2014 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors:
+ *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
+ */
+
+#include "bgpstream-test-rpki.h"
+#include "bgpstream_test.h"
+#include "bgpstream_utils_rpki.h"
+#include "utils.h"
+#include <stdio.h>
+#include <string.h>
+
+bgpstream_t *bs;
+bgpstream_data_interface_id_t di_id = 0;
+
+static int val_compare(const void *cmp1, const void *cmp2) {
+
+  /* Compare string for the sorting process */
+  return strcmp(*(const char **)cmp1, *(const char **)cmp2);
+}
+
+void sort(char *buf[], int n) {
+
+  /* Sort the  validation results */
+  qsort(buf, n, sizeof(const char *), val_compare);
+}
+
+int split_result(char *val_result, char **val_result_buf) {
+
+  /* Split the validation result into an string array */
+  int cnt = 0;
+  val_result_buf[cnt] = strtok(val_result, ";");
+  while (val_result_buf[cnt] != NULL) {
+    val_result_buf[++cnt] = strtok(NULL, ";");
+  }
+  return cnt;
+}
+
+int check_val_result(char *val_result, char *comp) {
+
+  /* Check if the validation are equal regardless of the order */
+  char *val_result_buf[1024];
+  char *comp_buf[1024];
+  int val_cnt = 0, comp_cnt = 0, check = 0;
+  sort(val_result_buf, val_cnt = split_result(val_result, val_result_buf));
+  sort(comp_buf, comp_cnt = split_result(comp, comp_buf));
+  for (int i = 0; i < val_cnt; i++) {
+    check += strcmp(val_result_buf[i], comp_buf[i]);
+  }
+  CHECK("Check Validation Result", !check);
+  return 0;
+}
+
+int generate_rpki_windows(rpki_window_t *rpki_windows, const int *testcase,
+                          int cnt) {
+
+  /* Generate a RPKI Window Instance */
+  int j = 0;
+  for (int i = 0; i < cnt; i += 2) {
+    rpki_windows[j].start = testcase[i];
+    rpki_windows[j].end = testcase[i + 1];
+    j++;
+  }
+  return j;
+}
+
+int test_rpki_create_input() {
+
+  bgpstream_rpki_input_t *input = bgpstream_rpki_create_input();
+  CHECK("Create Input", input != NULL);
+
+  CHECK("Project/Collector Input",
+        input->rpki_projects != NULL && input->rpki_collectors != NULL);
+  CHECK("SSH/Window Input",
+        input->rpki_ssh_arg != NULL && input->rpki_windows != NULL);
+  CHECK("Binary Input",
+        !input->rpki_historical && !input->rpki_unified && !input->rpki_ssh);
+  CHECK("Meta Input", !input->rpki_options_cnt && !input->rpki_active &&
+                          input->rpki_ptr == NULL && input->rpki_check == NULL);
+  return 0;
+}
+
+int test_rpki_parse_input() {
+
+  char *test_input = (char *)malloc(PARSING_SIZE * sizeof(char));
+
+  /* Check Binary Input */
+  snprintf(test_input, PARSING_SIZE, "%s", PARSING_BIN_TESTCASE_1);
+  bgpstream_rpki_input_t *input = bgpstream_rpki_parse_input(test_input);
+  CHECK("Parsing Bin Input #1",
+        input->rpki_active == 1 && input->rpki_args_check == 1);
+  snprintf(test_input, PARSING_SIZE, "%s", PARSING_BIN_TESTCASE_2);
+  input = bgpstream_rpki_parse_input(test_input);
+  CHECK("Parsing Bin Input #2",
+        input->rpki_active == 1 && input->rpki_args_check == 1);
+  snprintf(test_input, PARSING_SIZE, "%s", PARSING_BIN_TESTCASE_3);
+  input = bgpstream_rpki_parse_input(test_input);
+  CHECK("Parsing Bin Input #3",
+        input->rpki_active == 1 && input->rpki_args_check == 1);
+
+  PRINT_START;
+  snprintf(test_input, PARSING_SIZE, "%s", PARSING_BIN_TESTCASE_4);
+  input = bgpstream_rpki_parse_input(test_input);
+  CHECK("Parsing Bin Input #4", input->rpki_args_check == 0);
+  PRINT_END;
+
+  PRINT_MID;
+
+  /* Check SSH Input */
+  snprintf(test_input, PARSING_SIZE, "%s", PARSING_SSH_TESTCASE_1);
+  input = bgpstream_rpki_parse_input(test_input);
+  CHECK("Parsing SSH Input #1", input->rpki_args_check == 1);
+
+  PRINT_START;
+  snprintf(test_input, PARSING_SIZE, "%s", PARSING_SSH_TESTCASE_2);
+  input = bgpstream_rpki_parse_input(test_input);
+  CHECK("Parsing SSH Input #2", input->rpki_args_check == 0);
+  PRINT_END;
+
+  PRINT_MID;
+
+  /* Check Project and Collector Input */
+  snprintf(test_input, PARSING_SIZE, "%s", PARSING_PCC_TESTCASE_1);
+  input = bgpstream_rpki_parse_input(test_input);
+  CHECK("Parsing PC Input #1",
+        input->rpki_active == 1 && input->rpki_args_check == 1);
+  snprintf(test_input, PARSING_SIZE, "%s", PARSING_PCC_TESTCASE_2);
+  input = bgpstream_rpki_parse_input(test_input);
+  CHECK("Parsing PC Input #2",
+        input->rpki_active == 1 && input->rpki_args_check == 1);
+  return 0;
+}
+
+int test_rpki_parse_windows() {
+
+  /* Check RPKI Window Input */
+  struct rpki_window rpki_windows[WINDOW_CMD_CNT];
+  int cnt = ELEMS(PARSING_WND_TESTCASE_1);
+  int j = generate_rpki_windows(rpki_windows, PARSING_WND_TESTCASE_1, cnt);
+  bgpstream_rpki_input_t *input = bgpstream_rpki_create_input();
+  input = bgpstream_rpki_parse_windows(input, rpki_windows, j);
+  CHECK("Parsing Window Input #1",
+        !strcmp(input->rpki_windows, PARSING_WND_TESTCASE_1_RST));
+
+  cnt = ELEMS(PARSING_WND_TESTCASE_2);
+  j = generate_rpki_windows(rpki_windows, PARSING_WND_TESTCASE_2, cnt);
+  input = bgpstream_rpki_parse_windows(bgpstream_rpki_create_input(),
+                                       rpki_windows, j);
+  CHECK("Parsing Window Input #2",
+        !strcmp(input->rpki_windows, PARSING_WND_TESTCASE_2_RST));
+  return 0;
+}
+
+int test_rpki_validate() {
+
+  /* Declare BGPStream requirements */
+  int rrc = 0, counter = 0, erc = 0;
+  bgpstream_elem_t *bs_elem;
+  bgpstream_t *bs = bgpstream_create();
+  bgpstream_record_t *rec = NULL;
+  SETUP;
+  CHECK_SET_INTERFACE(singlefile);
+  bgpstream_data_interface_option_t *option;
+  option = bgpstream_get_data_interface_option_by_name(bs, di_id, "upd-file");
+  bgpstream_set_data_interface_option(bs, option,
+                                      "ris.rrc06.updates.1427846400.gz");
+  bgpstream_start(bs);
+
+  /* Create an input instance for hitorical validation (CC01) */
+  char *test_input = (char *)malloc(PARSING_SIZE * sizeof(char));
+  snprintf(test_input, PARSING_SIZE, "%s", VALIDATE_TESTCASE_1);
+  bgpstream_rpki_input_t *input = bgpstream_rpki_parse_input(test_input);
+
+  /* Create a RPKI window instance matching the testfile */
+  int VALIDATE_WND[2] = {1427846400, 1427846500};
+  struct rpki_window rpki_windows[WINDOW_CMD_CNT];
+  int j =
+      generate_rpki_windows(rpki_windows, VALIDATE_WND, ELEMS(VALIDATE_WND));
+  input = bgpstream_rpki_parse_windows(input, rpki_windows, j);
+  bgpstream_add_interval_filter(bs, rpki_windows[0].start, rpki_windows[0].end);
+
+  /* Set up a ROAFetchlib configuration */
+  rpki_cfg_t *cfg = bgpstream_rpki_set_cfg(input);
+  char val_result[VALIDATION_BUF];
+  char val_comp[VALIDATION_BUF];
+
+  /* Process every BGPStream elem and check the validation */
+  while ((rrc = bgpstream_get_next_record(bs, &rec)) > 0) {
+    if (rec->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
+      while ((erc = bgpstream_record_get_next_elem(rec, &bs_elem)) > 0) {
+        if (bs_elem->type == BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT) {
+          bs_elem->annotations.cfg = cfg;
+          bs_elem->annotations.rpki_active = input->rpki_active;
+          bs_elem->annotations.timestamp = rec->time_sec;
+          bgpstream_rpki_validate(bs_elem, val_result, sizeof(val_result));
+          snprintf(val_comp, sizeof(val_comp), "%s",
+                   VALIDATE_TESTCASE_RST2[counter]);
+          check_val_result(val_result, val_comp);
+          counter++;
+        }
+      }
+    }
+  }
+  return 0;
+}
+
+int main() {
+#ifdef WITH_RPKI
+  CHECK_SECTION("RPKI Input", !test_rpki_create_input());
+  CHECK_SECTION("RPKI Parsing", !test_rpki_parse_input());
+  CHECK_SECTION("RPKI Window Parsing", !test_rpki_parse_windows());
+  CHECK_SECTION("RPKI Validation", !test_rpki_validate());
+#endif
+  return 0;
+}

--- a/test/bgpstream-test-rpki.h
+++ b/test/bgpstream-test-rpki.h
@@ -1,0 +1,469 @@
+/*
+ * Copyright (C) 2014 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors:
+ *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <wandio.h>
+
+#define ELEMS(x) (sizeof(x) / sizeof((x)[0]))
+
+#define ERROR_START                                                            \
+  " * Intended Error-Check:\n"                                                 \
+  " * ------------------------------\n * "
+#define ERROR_END " * ------------------------------\n"
+
+#define PRINT_START                                                            \
+  do {                                                                         \
+    fprintf(stderr, ERROR_START);                                              \
+  } while (0)
+
+#define PRINT_MID                                                              \
+  do {                                                                         \
+    fprintf(stderr, " *\n");                                                   \
+  } while (0)
+
+#define PRINT_END                                                              \
+  do {                                                                         \
+    fprintf(stderr, ERROR_END);                                                \
+  } while (0)
+
+#define SETUP                                                                  \
+  do {                                                                         \
+    bs = bgpstream_create();                                                   \
+  } while (0)
+
+#define CHECK_SET_INTERFACE(interface)                                         \
+  do {                                                                         \
+    di_id = bgpstream_get_data_interface_id_by_name(bs, STR(interface));       \
+    bgpstream_set_data_interface(bs, di_id);                                   \
+  } while (0)
+
+#define PARSING_SIZE 2048
+#define VALIDATION_BUF 2048
+
+#define PARSING_BIN_TESTCASE_1 "1,0,0,FU-Berlin,CC01"
+#define PARSING_BIN_TESTCASE_2 "0,1,0,FU-Berlin,CC01"
+#define PARSING_BIN_TESTCASE_3 "0,0,0,FU-Berlin,CC01"
+#define PARSING_BIN_TESTCASE_4 "q,0,0,FU-Berlin,CC01"
+#define PARSING_SSH_TESTCASE_1                                                 \
+  "0,0,1,user,host_key,private_key,FU-Berlin,CC06(RTR)"
+#define PARSING_SSH_TESTCASE_2 "0,0,1,FU-Berlin,CC06(RTR)"
+#define PARSING_SSH_TESTCASE_3 "0,0,1"
+#define PARSING_PCC_TESTCASE_1                                                 \
+  "1,0,0,FU-Berlin,CC01,FU-Berlin,CC02,FU-Berlin,CC03,"                        \
+  "FU-Berlin,CC04,FU-Berlin,CC05(RTR),FU-Berlin,CC06(RTR),"                    \
+  "FU-Berlin,CC07,FU-Berlin,CC08(RTR),FU-Berlin,CC09(RTR),"
+
+#define PARSING_PCC_TESTCASE_2                                                 \
+  "1,0,0,FU-Berlin,CC01,FU-Berlin,CC02,FU-Berlin,CC03,"                        \
+  "FU-Berlin,CC04,FU-Berlin,CC05(RTR),FU-Berlin,CC06(RTR),"                    \
+  "FU-Berlin,CC07,FU-Berlin,CC08(RTR),FU-Berlin,CC09(RTR),"                    \
+  "FU-Berlin,CC10,FU-Berlin,CC11,FU-Berlin,CC12,"                              \
+  "FU-Berlin,CC13,FU-Berlin,CC14(RTR),FU-Berlin,CC15(RTR),"                    \
+  "FU-Berlin,CC16,FU-Berlin,CC17(RTR),FU-Berlin,CC18(RTR),"                    \
+  "FU-Berlin,CC19(RTR),FU-Berlin,CC20,FU-Berlin,CC21,"                         \
+  "FU-Berlin,CC22,FU-Berlin,CC23,FU-Berlin,CC24(RTR),"                         \
+  "FU-Berlin,CC25(RTR),FU-Berlin,CC26,FU-Berlin,CC27(RTR)"
+
+#define PARSING_WND_TESTCASE_1                                                 \
+  (const int[6]) {                                                             \
+    1506816000, 1506816000, 1506817000, 1506817100, 1506818000, 1506818100     \
+  }
+
+#define PARSING_WND_TESTCASE_2                                                 \
+  (const int[24]) {                                                            \
+    1506816000, 1506816100, 1506817000, 1506817100, 1506818000, 1506818100,    \
+        1506819000, 1506819100, 1506820000, 1506812100, 1506821000,            \
+        1506821100, 1506822000, 1506822100, 1506823000, 1506823100,            \
+        1506824000, 1506824100, 1506825000, 1506825100, 1506826000,            \
+        1506826100, 1506827000, 1506827100                                     \
+  }
+
+#define PARSING_WND_TESTCASE_1_RST                                             \
+  "1506816000-1506816000,1506817000-1506817100,"                               \
+  "1506818000-1506818100"
+#define PARSING_WND_TESTCASE_2_RST                                             \
+  "1506816000-1506816100,1506817000-1506817100,"                               \
+  "1506818000-1506818100,1506819000-1506819100,"                               \
+  "1506820000-1506812100,1506821000-1506821100,"                               \
+  "1506822000-1506822100,1506823000-1506823100,"                               \
+  "1506824000-1506824100,1506825000-1506825100,"                               \
+  "1506826000-1506826100,1506827000-1506827100"
+
+#define VALIDATE_TESTCASE_1 "1,0,0,FU-Berlin,CC06(RTR)"
+#define VALIDATE_TESTCASE_RST2                                                 \
+  (const char * [517]) {                                                       \
+    "FU-Berlin,CC06(RTR),notfound;",                                           \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.73.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe10::/48-48;",              \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.66.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:ff02::/48-48;",              \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:ff02::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:ff02::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,50530,2a00:1ce0::/32-48;",                  \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,47524,176.240.0.0/16-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.78.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe0e::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.77.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.77.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,47524,176.240.0.0/16-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.67.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,47524,176.240.0.0/16-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.79.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,27891,2800:a020::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe05::/48-48;",              \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.69.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,47524,176.240.0.0/16-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,47524,176.240.0.0/16-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe0a::/48-48;",              \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.74.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/"                   \
+        "15-16;FU-Berlin,CC06(RTR),valid,27891,150.187.178.0/24-24;",          \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/"                   \
+        "15-16;FU-Berlin,CC06(RTR),valid,27686,150.186.112.0/20-20;",          \
+        "FU-Berlin,CC06(RTR),valid,27807,150.185.0.0/"                         \
+        "16-16;FU-Berlin,CC06(RTR),valid,20312,150.185.0.0/"                   \
+        "16-20;FU-Berlin,CC06(RTR),valid,27892,150.185.192.0/24-24;",          \
+        "FU-Berlin,CC06(RTR),valid,27807,150.185.0.0/"                         \
+        "16-16;FU-Berlin,CC06(RTR),valid,20312,150.185.0.0/"                   \
+        "16-20;FU-Berlin,CC06(RTR),valid,27892,150.185.222.0/24-24;",          \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),invalid,20312,150.186.0.0/"                       \
+        "15-19;FU-Berlin,CC06(RTR),invalid,27807,150.186.0.0/"                 \
+        "15-16;FU-Berlin,CC06(RTR),invalid,17287,150.186.32.0/19-19;",         \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,47524,176.240.0.0/16-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/"                   \
+        "15-16;FU-Berlin,CC06(RTR),valid,27890,150.186.64.0/19-19;",           \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/"                   \
+        "15-16;FU-Berlin,CC06(RTR),valid,27891,150.187.142.0/24-24;",          \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/"                   \
+        "15-16;FU-Berlin,CC06(RTR),valid,27891,150.187.145.0/24-24;",          \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/"                   \
+        "15-16;FU-Berlin,CC06(RTR),valid,27891,150.187.141.0/24-24;",          \
+        "FU-Berlin,CC06(RTR),valid,27891,190.168.192.0/18-18;",                \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/"                   \
+        "15-16;FU-Berlin,CC06(RTR),valid,27891,150.187.148.0/24-24;",          \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,27807,150.185.0.0/"                         \
+        "16-16;FU-Berlin,CC06(RTR),valid,20312,150.185.0.0/"                   \
+        "16-20;FU-Berlin,CC06(RTR),valid,23007,150.185.128.0/18-18;",          \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,47524,176.240.0.0/16-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,31078,2a00:1328::/32-36;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe03::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe03::/48-48;",              \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.67.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.67.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe03::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,27820,2800:130::/32-32;",                   \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:ff02::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.64.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.192.0/21-21;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,195.137.144.0/22-22;",                \
+        "FU-Berlin,CC06(RTR),valid,60822,185.85.212.0/22-22;",                 \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.204.0/22-22;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.200.0/22-22;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.192.0/21-21;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,195.137.144.0/22-22;",                \
+        "FU-Berlin,CC06(RTR),valid,60822,185.85.212.0/22-22;",                 \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.204.0/22-22;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.200.0/22-22;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.192.0/21-21;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,195.137.144.0/22-22;",                \
+        "FU-Berlin,CC06(RTR),valid,60822,185.85.212.0/22-22;",                 \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.204.0/22-22;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.200.0/22-22;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,27820,2800:130::/32-32;",                   \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,27807,150.185.0.0/"                         \
+        "16-16;FU-Berlin,CC06(RTR),valid,20312,150.185.0.0/16-20;",            \
+        "FU-Berlin,CC06(RTR),valid,20312,150.188.0.0/"                         \
+        "15-24;FU-Berlin,CC06(RTR),valid,27807,150.188.0.0/15-16;",            \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/15-16;",            \
+        "FU-Berlin,CC06(RTR),valid,20312,150.186.0.0/"                         \
+        "15-19;FU-Berlin,CC06(RTR),valid,27807,150.186.0.0/15-16;",            \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,47524,176.240.0.0/16-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,31078,2a00:1328::/32-36;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,31078,2a00:1328::/32-36;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,31078,2a00:1328::/32-36;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe00::/48-48;",              \
+        "FU-Berlin,CC06(RTR),valid,10091,2404:e800::/31-64;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,18747,190.60.0.0/15-24;",                   \
+        "FU-Berlin,CC06(RTR),valid,18747,190.60.0.0/15-24;",                   \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:fe00::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:ff02::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.192.0/21-21;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,195.137.144.0/22-22;",                \
+        "FU-Berlin,CC06(RTR),valid,60822,185.85.212.0/22-22;",                 \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.204.0/22-22;",                  \
+        "FU-Berlin,CC06(RTR),valid,60822,46.23.200.0/22-22;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.64.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,10091,2404:e800::/31-64;",                  \
+        "FU-Berlin,CC06(RTR),valid,12654,2001:7fb:ff02::/48-48;",              \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,12654,84.205.64.0/24-24;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,27820,2800:130::/32-32;",                   \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,35226,2a02:2158::/32-32;",                  \
+        "FU-Berlin,CC06(RTR),valid,31078,2a00:1328::/32-36;",                  \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),valid,201565,185.11.232.0/22-22;",                \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;",                                       \
+        "FU-Berlin,CC06(RTR),invalid,9050,188.214.141.0/24-24;",               \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;",      \
+        "FU-Berlin,CC06(RTR),notfound;", "FU-Berlin,CC06(RTR),notfound;"       \
+  }

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -241,11 +241,6 @@ int main(int argc, char *argv[])
 #ifdef WITH_RPKI
   struct rpki_window rpki_windows[WINDOW_CMD_CNT];
   bgpstream_rpki_input_t *rpki_input = NULL;
-  /*char* test_input = (char*) malloc(25*sizeof(char));
-  snprintf(test_input, 25, "%s", "1,0,0,FU-Berlin,CC01");
-  rpki_input = bgpstream_rpki_parse_input(test_input);
-  printf("%i\n", rpki_input->rpki_args_check);
-  exit(-1);*/
 #endif
 
   char *filterstring = NULL;
@@ -646,7 +641,7 @@ int main(int argc, char *argv[])
 
 #ifdef WITH_RPKI
   if(rpki_input != NULL && rpki_input->rpki_active){
-    cfg_destroy(cfg);
+    bgpstream_rpki_destroy_cfg(cfg);
     bgpstream_rpki_destroy_input(rpki_input);
   }
 #endif
@@ -660,7 +655,7 @@ err:
   bgpstream_destroy(bs);
 #ifdef WITH_RPKI
   if(rpki_input != NULL && rpki_input->rpki_active){
-    cfg_destroy(cfg);
+    bgpstream_rpki_destroy_cfg(cfg);
     bgpstream_rpki_destroy_input(rpki_input);
   }
 #endif

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -39,6 +39,10 @@
 #include <time.h>
 #include <unistd.h>
 #include <unistd.h>
+#ifdef WITH_RPKI
+#include "utils/bgpstream_utils_rpki.h"
+#include <roafetchlib/roafetchlib.h>
+#endif
 #include "bgpstream.h"
 
 #define PROJECT_CMD_CNT 10
@@ -183,6 +187,14 @@ static void usage()
     "   -i             print format information before output\n"
     "\n"
     "   -n <rec-cnt>   process at most <rec-cnt> records\n"
+#ifdef WITH_RPKI
+    "   -H <historical-mode>,<unified>,<ssh_enabled>,\n"
+    "      [<ssh_user>,<ssh_hostkey_path>,<ssh_privkey_path>]?,\n"
+    "      <project_1>,<collector_1>[,<project_n>,<collector_n>]*\n"
+    "                  enables RPKI support for historical or live validation\n"
+    "                  where <historical-mode>, <unified> and <ssh_enabled> can be 0 or 1\n"
+    "\n"
+#endif
     "   -h             print this help menu\n"
     "* denotes an option that can be given multiple times\n");
 }
@@ -226,6 +238,16 @@ int main(int argc, char *argv[])
   char *interface_options[OPTION_CMD_CNT];
   int interface_options_cnt = 0;
 
+#ifdef WITH_RPKI
+  struct rpki_window rpki_windows[WINDOW_CMD_CNT];
+  bgpstream_rpki_input_t *rpki_input = NULL;
+  /*char* test_input = (char*) malloc(25*sizeof(char));
+  snprintf(test_input, 25, "%s", "1,0,0,FU-Berlin,CC01");
+  rpki_input = bgpstream_rpki_parse_input(test_input);
+  printf("%i\n", rpki_input->rpki_args_check);
+  exit(-1);*/
+#endif
+
   char *filterstring = NULL;
   char *intervalstring = NULL;
 
@@ -256,7 +278,7 @@ int main(int argc, char *argv[])
   bgpstream_record_t *bs_record = NULL;
 
   while (prevoptind = optind,
-         (opt = getopt(argc, argv, "f:I:d:o:p:c:t:w:j:k:y:P:n:lrmeivh?")) >= 0) {
+         (opt = getopt(argc, argv, "f:I:d:o:p:c:t:w:j:k:y:P:n:H:lrmeivh?")) >= 0) {
     if (optind == prevoptind + 2 && (optarg == NULL || *optarg == '-')) {
       opt = ':';
       --optind;
@@ -368,6 +390,16 @@ int main(int argc, char *argv[])
       rec_limit = atoi(optarg);
       fprintf(stderr, "INFO: Processing at most %d records\n", rec_limit);
       break;
+
+#ifdef WITH_RPKI
+    case 'H':      
+      rpki_input = bgpstream_rpki_parse_input(optarg);
+      if(!rpki_input->rpki_args_check){
+        bgpstream_rpki_destroy_input(rpki_input);
+        usage(); exit(-1);
+      }
+      break;
+#endif
 
     case 'l':
       live = 1;
@@ -549,6 +581,15 @@ int main(int argc, char *argv[])
   int rrc = 0, erc = 0, rec_cnt = 0;
   bgpstream_elem_t *bs_elem;
 
+#ifdef WITH_RPKI
+  rpki_cfg_t *cfg = NULL;
+  if(rpki_input != NULL && rpki_input->rpki_active){
+    memcpy(&rpki_windows, &windows, sizeof(rpki_windows));
+    rpki_input = bgpstream_rpki_parse_windows(rpki_input, rpki_windows, windows_cnt);
+    cfg = bgpstream_rpki_set_cfg(rpki_input);
+  }
+#endif
+
   while ((rrc = bgpstream_get_next_record(bs, &bs_record)) > 0 &&
          (rec_limit < 0 || rec_cnt < rec_limit)) {
     rec_cnt++;
@@ -575,6 +616,13 @@ int main(int argc, char *argv[])
       }
 
       while ((erc = bgpstream_record_get_next_elem(bs_record, &bs_elem)) > 0) {
+#ifdef WITH_RPKI
+        if(rpki_input != NULL && rpki_input->rpki_active){
+          bs_elem->annotations.cfg = cfg;
+          bs_elem->annotations.rpki_active = rpki_input->rpki_active;
+          bs_elem->annotations.timestamp = bs_record->time_sec;            
+        }
+#endif
         if (print_elem(bs_record, bs_elem) != 0) {
           goto err;
         }
@@ -596,6 +644,13 @@ int main(int argc, char *argv[])
     goto err;
   }
 
+#ifdef WITH_RPKI
+  if(rpki_input != NULL && rpki_input->rpki_active){
+    cfg_destroy(cfg);
+    bgpstream_rpki_destroy_input(rpki_input);
+  }
+#endif
+
  done:
   /* deallocate memory for interface */
   bgpstream_destroy(bs);
@@ -603,6 +658,12 @@ int main(int argc, char *argv[])
 
 err:
   bgpstream_destroy(bs);
+#ifdef WITH_RPKI
+  if(rpki_input != NULL && rpki_input->rpki_active){
+    cfg_destroy(cfg);
+    bgpstream_rpki_destroy_input(rpki_input);
+  }
+#endif
   return -1;
 }
 


### PR DESCRIPTION
- The configure script checks whether the shared library is available or not and supports the option —without-rpki

- The bgpreader accepts another parameter (H) which allows to set all necessary RPKI options:
<historical-mode> - Validation in historical or live mode
<unified> - Whether all ROAs of all collectors are combined or not
<ssh_enabled> - Whether to connect to a RTR server via SSH
[<ssh_user>,<ssh_hostkey_path>,<ssh_privkey_path>]?, - User, HK, PK
<project_1>,<collector_1> - Project and collector name of collector #1
[,<project_n>,<collector_n>]* - More projects and collectors separated with comma

- Creates the configuration for the validation process and sets it for every BGP elem

- During the output process the current BGP elem will be validated and the corresponding validation result will be printed as well