### PR TITLE
Remove explicit initialization of static option variables

### DIFF
--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -137,8 +137,8 @@ struct options{
   char* expl;
 };
 
-static struct option long_options [OPTIONS_CNT + 1] = {0};
-static char short_options[OPTIONS_CNT * 2 + 1] = {0};
+static struct option long_options [OPTIONS_CNT + 1];
+static char short_options[OPTIONS_CNT * 2 + 1];
 
 struct window {
   uint32_t start;


### PR DESCRIPTION
This was causing problems with gcc 4.8 and clang, and is not necessary since even if static variables weren't initialized to 0, it seems that we don't depend on initialization anyway.