### PR TITLE
RPKI Prefix Origin Validation Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ ChangeLog
 tools/bgpreader
 test/bgpstream-test
 test/bgpstream-test-filters
+test/bgpstream-test-rpki
 test/bgpstream-test-utils-addr
 test/bgpstream-test-utils-pfx
 test/bgpstream-test-utils-patricia

--- a/configure.ac
+++ b/configure.ac
@@ -262,10 +262,10 @@ fi
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([---- RPKI support configuration ----])
 AC_ARG_WITH([rpki],
-        [AS_HELP_STRING([--without-rpki],
-        [do not compile with rpki support])],
+        [AS_HELP_STRING([--with-rpki],
+        [bulding with rpki support])],
         [],
-        [with_rpki=yes])
+        [with_rpki=no])
 AM_CONDITIONAL([WITH_RPKI], [test "x$with_rpki" != xno])
 if test x"$with_rpki" = xyes; then
     AC_CHECK_LIB([roafetch], [rpki_set_config],,

--- a/configure.ac
+++ b/configure.ac
@@ -258,6 +258,27 @@ if test "x$with_di_csvfile" == xyes; then
    BS_DI_OPT(csvfile-csv-file, CSVFILE_CSV_FILE, CSV file listing the MRT data to read, not-set)
 fi
 
+# RPKI configuration (ROAFetchLib)
+AC_MSG_NOTICE([])
+AC_MSG_NOTICE([---- RPKI support configuration ----])
+AC_ARG_WITH([rpki],
+        [AS_HELP_STRING([--without-rpki],
+        [do not compile with rpki support])],
+        [],
+        [with_rpki=yes])
+AM_CONDITIONAL([WITH_RPKI], [test "x$with_rpki" != xno])
+if test x"$with_rpki" = xyes; then
+    AC_CHECK_LIB([roafetch], [rpki_set_config],,
+         [AC_MSG_ERROR(
+            [ROAFetchlib is required (--without-rpki to disable)]
+    )])
+    AC_DEFINE([WITH_RPKI],[1],[Building with RPKI support])
+    AC_DEFINE([RPKI_BROKER],["http://roa-broker.realmv6.org"],[RPKI broker])
+else
+  AC_MSG_CHECKING([whether to build with RPKI support])
+  AC_MSG_RESULT([no])
+fi
+
 AC_HEADER_ASSERT
 
 AC_CONFIG_FILES([Makefile

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -29,6 +29,9 @@
 #include "bgpstream_record.h"
 #include "bgpstream_utils.h"
 #include "config.h"
+#ifdef WITH_RPKI
+#include "bgpstream_utils_rpki.h"
+#endif
 #include "utils.h"
 #include <assert.h>
 #include <inttypes.h>
@@ -326,6 +329,20 @@ char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
     /* NEW STATE (empty) */
     if (B_FULL)
       return NULL;
+
+#ifdef WITH_RPKI
+    /* RPKI validation */
+    /* If the RPKI parameter was set, the corresponding input was valid and the 
+        configure was completely set up -> the elem can be validated by RPKI */
+    if(elem->annotations.rpki_active){
+      char result[B_REMAIN];
+      if(bgpstream_rpki_validate(elem, result, sizeof(result))){
+        c = snprintf(buf_p, B_REMAIN, "%s", result);
+        written += c;
+        buf_p += c;
+      }
+    }
+#endif
 
     /* END OF LINE */
     break;

--- a/lib/bgpstream_elem.h
+++ b/lib/bgpstream_elem.h
@@ -107,6 +107,19 @@ typedef enum {
 
 } bgpstream_elem_type_t;
 
+typedef struct struct_bgpstream_annotations_t {
+  
+  /** RPKI active */
+  int rpki_active;
+
+  /** RPKI validation configuration */
+  struct struct_rpki_config_t *cfg;
+
+  /** Record timestamp */
+  uint32_t timestamp;
+
+} bgpstream_annotations_t;
+
 /** @} */
 
 /**
@@ -186,6 +199,12 @@ typedef struct bgpstream_elem {
    * Available only for the Peer-state elem type
    */
   bgpstream_elem_peerstate_t new_state;
+
+  /** Annotations
+   *
+   * Annotations from other libraries
+   */
+  bgpstream_annotations_t annotations;
 
 } bgpstream_elem_t;
 

--- a/lib/utils/Makefile.am
+++ b/lib/utils/Makefile.am
@@ -35,6 +35,15 @@ noinst_LTLIBRARIES = libbgpstream-utils.la
 
 CONDITIONAL_LIBS=
 
+# Compile RPKI files only if WITH_RPKI is set
+if WITH_RPKI
+RPKI_SRCS=bgpstream_utils_rpki.c bgpstream_utils_rpki.h
+RPKI_HDRS=bgpstream_utils_rpki.h
+else
+RPKI_SRCS=
+RPKI_HDRS=
+endif
+
 include_HEADERS= bgpstream_utils.h 		     \
 		 bgpstream_utils_addr.h 	     \
 		 bgpstream_utils_addr_set.h	     \
@@ -48,7 +57,8 @@ include_HEADERS= bgpstream_utils.h 		     \
 		 bgpstream_utils_str_set.h	     \
 		 bgpstream_utils_ip_counter.h	     \
 	         bgpstream_utils_patricia.h  \
-		 bgpstream_utils_time.h
+		 bgpstream_utils_time.h  \
+		 $(RPKI_HDRS)
 
 
 libbgpstream_utils_la_SOURCES =             \
@@ -80,7 +90,8 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_patricia.c	    \
 	bgpstream_utils_patricia.h		\
 	bgpstream_utils_time.c    \
-	bgpstream_utils_time.h
+	bgpstream_utils_time.h    \
+	$(RPKI_SRCS)
 
 
 libbgpstream_utils_la_LIBADD = $(CONDITIONAL_LIBS)

--- a/lib/utils/bgpstream_utils_rpki.c
+++ b/lib/utils/bgpstream_utils_rpki.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2014 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors:
+ *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "config.h"
+#include "utils.h"
+#include "bgpstream_utils_rpki.h"
+
+bgpstream_rpki_input_t *bgpstream_rpki_create_input()
+{
+  /* Create a BGPStream RPKI input struct instance */
+  bgpstream_rpki_input_t *input = NULL;
+  size_t input_size = sizeof(bgpstream_rpki_input_t);
+  if ((input = (bgpstream_rpki_input_t *)malloc_zero(input_size)) == NULL) {
+    return NULL;
+  }
+
+  return input;
+}
+
+void bgpstream_rpki_destroy_input(bgpstream_rpki_input_t *input)
+{
+  /* Destroy a BGPStream RPKI input struct instance if necessary */
+  if (input == NULL) {
+    return;
+  }
+  free(input);
+}
+
+rpki_cfg_t *bgpstream_rpki_set_cfg(bgpstream_rpki_input_t *inp)
+{
+  /* Set up the ROAFetchlib configuration */
+  return rpki_set_config(inp->rpki_collectors, inp->rpki_windows,
+      inp->rpki_unified, !inp->rpki_live, RPKI_BROKER, inp->rpki_ssh_ptr);
+}
+
+void bgpstream_rpki_destroy_cfg(rpki_cfg_t *cfg)
+{
+  /* Destroy the ROAFetchlib configuration if necessary */
+  if (cfg == NULL) {
+    return;
+  }
+  rpki_destroy_config(cfg);
+}
+
+int bgpstream_rpki_parse_windows(bgpstream_rpki_input_t *input,
+                                 rpki_window_t windows[WINDOW_CMD_CNT],
+                                 int windows_cnt)
+{
+  /* Parse all BGPReader window arguments (assuming a unix timestamp len of 10)
+     Format: WD_1-WD2,WD3-WD4, chk_len calculates the string length */
+  int rst = 0;
+  int chk_len = (windows_cnt * 2) * 10 + (2 * windows_cnt - 1);
+  for (int i = 0; i < windows_cnt; i++) {
+    size_t size = strlen(input->rpki_windows);
+    rst+= snprintf(input->rpki_windows + size, sizeof(input->rpki_windows)
+                       - size, i < windows_cnt - 1 ? "%"PRIu32 "-%"PRIu32 "," :
+                       "%"PRIu32 "-%"PRIu32, windows[i].start, windows[i].end);
+  }
+
+  return rst == chk_len;
+}
+
+void bgpstream_rpki_parse_live(bgpstream_rpki_input_t *inp)
+{
+  /* Add the mode parameter to the input struct and set RPKI active */
+  inp->rpki_active = 1;
+  inp->rpki_live = 1;
+}
+
+void bgpstream_rpki_parse_unified(bgpstream_rpki_input_t *inp)
+{
+  /* Add the unified parameter to the input struct */
+  inp->rpki_unified = 1;
+}
+
+void bgpstream_rpki_parse_ssh(char *optarg, bgpstream_rpki_input_t *inp)
+{
+  /* Add the SSH parameters to the input struct */
+  inp->rpki_ssh_ptr = inp->rpki_ssh;
+  snprintf(inp->rpki_ssh_ptr, sizeof(inp->rpki_ssh), "%s", optarg);
+}
+
+void bgpstream_rpki_parse_collectors(char *optarg, bgpstream_rpki_input_t *inp)
+{
+  /* Add the collectors parameter to the input struct and set RPKI active */
+  inp->rpki_active = 1;
+  snprintf(inp->rpki_collectors, sizeof(inp->rpki_collectors), "%s", optarg);
+}
+
+void bgpstream_rpki_parse_default(bgpstream_rpki_input_t *inp)
+{
+  /* If the default mode is active, set RPKI active without a spec. collector */
+  inp->rpki_active = 1;
+}
+
+int bgpstream_rpki_validate(bgpstream_elem_t const *elem, char *result,
+                            size_t size)
+{
+  /* Validate a BGP elem with the ROAFetchlib */
+  int val_rst = 0;
+  char prefix[INET6_ADDRSTRLEN];
+  bgpstream_addr_ntop(prefix, INET6_ADDRSTRLEN,
+                      &(((bgpstream_pfx_t *)&(elem->prefix))->address));
+  uint32_t asn = 0;
+
+  /* Validate the BGP elem only if the origin ASN is a simple ASN value
+     (i.e. not a set). If the validation function of the ROAFetchlib
+     returns 0 -> a valid result (val_rst = 1) is available */
+  if (!bgpstream_as_path_get_origin_val(elem->as_path, &asn)) {
+    if (!rpki_validate(elem->annotations.cfg, elem->annotations.timestamp, asn,
+                       prefix, elem->prefix.mask_len, result, size)) {
+      val_rst = 1;
+    }
+  }
+
+  return val_rst;
+}

--- a/lib/utils/bgpstream_utils_rpki.h
+++ b/lib/utils/bgpstream_utils_rpki.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2014 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors:
+ *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
+ */
+
+#ifndef __BGPSTREAM_UTILS_RPKI_H
+#define __BGPSTREAM_UTILS_RPKI_H
+
+#include <stdint.h>
+#include <roafetchlib/roafetchlib.h>
+#include "bgpstream_elem.h"
+
+// Note the copy of the BGPStream - Window Command Count !!
+#define WINDOW_CMD_CNT 1024
+
+#define RPKI_CMD_CNT 2048
+#define RPKI_SSH_BUFLEN 2048
+#define RPKI_WINDOW_LEN 24
+
+/** A BGPStream RPKI Window object */
+typedef struct rpki_window {
+  uint32_t start;
+  uint32_t end;
+} rpki_window_t;
+
+/** A BGPStream RPKI Input object */
+typedef struct bgpstream_rpki_input {
+
+  /** RPKI windows
+   *
+   * RPKI time interval windows for the validation
+   */
+  char rpki_windows[WINDOW_CMD_CNT * RPKI_WINDOW_LEN];
+
+  /** RPKI collectors
+   *
+   * RPKI collectors
+   */
+  char rpki_collectors[RPKI_CMD_CNT];
+
+  /** RPKI SSH arguments
+   *
+   * RPKI SSH arguments to connect to a cache server via SSH
+   */
+  char rpki_ssh[RPKI_SSH_BUFLEN];
+
+  /** RPKI SSH arguments (pointer)
+   *
+   * Pointer to the RPKI SSH arguments
+   */
+  char *rpki_ssh_ptr;
+
+  /** RPKI mode
+   *
+   * Mode of the validation - historical(0) or live(1)
+   */
+  int rpki_live;
+
+  /** RPKI unified
+   *
+   * Whether the validation is separate(0) or unified(1)
+   */
+  int rpki_unified;
+
+  /** RPKI active
+   *
+   * Whether the RPKI support is active
+   */
+  int rpki_active;
+
+} bgpstream_rpki_input_t;
+
+
+/** Public Functions */
+
+/** Create a BGPStream RPKI input struct instance
+ *
+ * @return             Pointer to the BGPStream RPKI input struct
+ */
+bgpstream_rpki_input_t *bgpstream_rpki_create_input();
+
+/** Destroy a BGPStream RPKI input struct instance
+ *
+ * @param input        Pointer to the BGPStream RPKI input struct
+ */
+void bgpstream_rpki_destroy_input(bgpstream_rpki_input_t *input);
+
+/** Parse all BGPStream RPKI window arguments
+ *
+ * @param input        Pointer to the BGPStream RPKI input struct
+ * @param windows      Array of rpki_window_t structs
+ * @param windows_cnt  Number of BGPStream RPKI interval windows
+ * @return             1 if the parsing process was valid - 0 otherwise
+ */
+int bgpstream_rpki_parse_windows(bgpstream_rpki_input_t *input,
+                             rpki_window_t windows[WINDOW_CMD_CNT],
+                             int windows_cnt);
+
+/** Add the mode argument to the input struct and set RPKI active
+ *
+ * @param inp          Pointer to the BGPStream RPKI input struct
+ */
+void bgpstream_rpki_parse_live(bgpstream_rpki_input_t *inp);
+
+/** Add the unified argument to the input struct
+ *
+ * @param inp          Pointer to the BGPStream RPKI input struct
+ */
+void bgpstream_rpki_parse_unified(bgpstream_rpki_input_t *inp);
+
+/** Add the SSH arguments to the input struct
+ *
+ * @param optarg       Pointer to the arguments buffer
+ * @param inp          Pointer to the BGPStream RPKI input struct
+ */
+void bgpstream_rpki_parse_ssh(char *optarg, bgpstream_rpki_input_t *inp);
+
+/** Add the collectors arguments to the input struct
+ *
+ * @param optarg       Pointer to the arguments buffer
+ * @param inp          Pointer to the BGPStream RPKI input struct
+ */
+void bgpstream_rpki_parse_collectors(char *optarg, bgpstream_rpki_input_t *inp);
+
+/** If the default mode is active, set RPKI active without a specific collector
+ *
+ * @param inp          Pointer to the BGPStream RPKI input struct
+ */
+void bgpstream_rpki_parse_default(bgpstream_rpki_input_t *inp);
+
+/** Set up the ROAFetchlib configuration
+ *
+ * @param input        Pointer to the BGPStream RPKI input struct
+ * @return             Pointer to the ROAFetchlib configuration
+ */
+rpki_cfg_t *bgpstream_rpki_set_cfg(bgpstream_rpki_input_t *input);
+
+/** Destroy the ROAFetchlib configuration
+ *
+ * @param cfg          Pointer to the ROAFetchlib configuration
+ */
+void bgpstream_rpki_destroy_cfg(rpki_cfg_t *cfg);
+
+/** Validate a BGP elem with the ROAFetchlib if the Annoucement contains an
+ * unique origin AS
+ *
+ * @param elem         Pointer to a BGPStream Elem instance
+ * @param result       Pointer to buffer for the validation result
+ * @param size         Size of the validation result buffer
+ * @return             1 if the validation process was valid - 0 otherwise
+ */
+int bgpstream_rpki_validate(bgpstream_elem_t const *elem, char *result,
+                            size_t size);
+
+#endif /* __BGPSTREAM_UTILS_RPKI_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,25 +29,37 @@ AM_CPPFLAGS = 	-I$(top_srcdir) \
 	 	-I$(top_srcdir)/lib/utils \
 	 	-I$(top_srcdir)/common
 
+# Run bgpstream-test-rpki only if WITH_RPKI is set
+if WITH_RPKI
+RPKI_TEST=bgpstream-test-rpki
+else
+RPKI_TEST=
+endif
+
 TESTS = 				\
 	bgpstream-test 			\
 	bgpstream-test-filters		\
 	bgpstream-test-utils-addr 	\
 	bgpstream-test-utils-pfx	\
-	bgpstream-test-utils-patricia
+	bgpstream-test-utils-patricia 			\
+  $(RPKI_TEST)
 
 check_PROGRAMS =  			\
 	bgpstream-test 			\
 	bgpstream-test-filters		\
 	bgpstream-test-utils-addr 	\
 	bgpstream-test-utils-pfx	\
-	bgpstream-test-utils-patricia
+	bgpstream-test-utils-patricia  \
+  $(RPKI_TEST)
 
 bgpstream_test_SOURCES = bgpstream-test.c bgpstream_test.h
 bgpstream_test_LDADD   = $(top_builddir)/lib/libbgpstream.la
 
 bgpstream_test_filters_SOURCES = bgpstream-test-filters.c bgpstream_test.h
 bgpstream_test_filters_LDADD   = $(top_builddir)/lib/libbgpstream.la
+
+bgpstream_test_rpki_SOURCES = bgpstream-test-rpki.c bgpstream_test.h
+bgpstream_test_rpki_LDADD   = $(top_builddir)/lib/libbgpstream.la
 
 bgpstream_test_utils_addr_SOURCES = bgpstream-test-utils-addr.c bgpstream_test.h
 bgpstream_test_utils_addr_LDADD   = $(top_builddir)/lib/libbgpstream.la

--- a/test/bgpstream-test-rpki.c
+++ b/test/bgpstream-test-rpki.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2014 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors:
+ *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "utils.h"
+#include "bgpstream-test-rpki.h"
+#include "bgpstream_test.h"
+#include "bgpstream_utils_rpki.h"
+
+bgpstream_t *bs;
+bgpstream_data_interface_id_t di_id = 0;
+
+int check_val_result(char *val_result, char *comp, int cnt) {
+
+  /* Check whether the validation results are equal */
+  char test_num[VALIDATION_BUF] = {0};
+  snprintf(test_num, sizeof(test_num), "Check Validation Result #%i", cnt);
+  CHECK_RPKI_RESULT(test_num, !strcmp(val_result, comp));
+  return strcmp(val_result, comp);
+}
+
+int generate_rpki_windows(rpki_window_t *rpki_windows, const int *testcase,
+                          int cnt) {
+
+  /* Generate a RPKI Window Instance */
+  int j = 0;
+  for (int i = 0; i < cnt; i += 2) {
+    rpki_windows[j].start = testcase[i];
+    rpki_windows[j].end = testcase[i + 1];
+    j++;
+  }
+  return j;
+}
+
+int test_rpki_create_input() {
+
+  bgpstream_rpki_input_t *input = bgpstream_rpki_create_input();
+  CHECK_RPKI_RESULT("Create Input", input != NULL);
+  CHECK_RPKI_RESULT("Collectors arguments", !strlen(input->rpki_collectors));
+  CHECK_RPKI_RESULT("SSH arguments", !strlen(input->rpki_ssh));
+  CHECK_RPKI_RESULT("Window arguments", !strlen(input->rpki_windows));
+  CHECK_RPKI_RESULT("Live argument", !input->rpki_live && !input->rpki_unified);
+  CHECK_RPKI_RESULT("Unified argument", !input->rpki_live &&
+                                        !input->rpki_unified);
+  CHECK_RPKI_RESULT("Meta flags", !input->rpki_active &&
+                                  input->rpki_ssh_ptr == NULL);
+  return 0;
+}
+
+int test_rpki_parse_input() {
+
+  /* Check live/historical mode argument */
+  bgpstream_rpki_input_t *input = bgpstream_rpki_create_input();
+  bgpstream_rpki_parse_live(input);
+  CHECK_RPKI_RESULT("Parsing RPKI mode parameter", input->rpki_active &&
+                                                   input->rpki_live);
+  bgpstream_rpki_destroy_input(input);
+
+  /* Check unified argument */
+  input = bgpstream_rpki_create_input();
+  bgpstream_rpki_parse_unified(input);
+  CHECK_RPKI_RESULT("Parsing RPKI unified parameter", input->rpki_unified == 1);
+  bgpstream_rpki_destroy_input(input);
+
+  /* Check SSH arguments */
+  input = bgpstream_rpki_create_input();
+  bgpstream_rpki_parse_ssh(PARSING_SSH_TESTCASE_1, input);
+  CHECK_RPKI_RESULT("Parsing RPKI SSH arguments", !strcmp(input->rpki_ssh,
+                    PARSING_SSH_TESTCASE_1) && input->rpki_ssh_ptr != NULL);
+  bgpstream_rpki_destroy_input(input);
+
+  /* Check collectors arguments */
+  input = bgpstream_rpki_create_input();
+  bgpstream_rpki_parse_collectors(PARSING_PCC_TESTCASE_1, input);
+  CHECK_RPKI_RESULT("Parsing RPKI collectors arguments",
+                    !strcmp(input->rpki_collectors, PARSING_PCC_TESTCASE_1) &&
+                    input->rpki_active);
+  bgpstream_rpki_destroy_input(input);
+
+  /* Check default arguments */
+  input = bgpstream_rpki_create_input();
+  bgpstream_rpki_parse_default(input);
+  CHECK_RPKI_RESULT("Parsing RPKI default parameter", input->rpki_active);
+  bgpstream_rpki_destroy_input(input);
+
+  return 0;
+}
+
+int test_rpki_parse_windows() {
+
+  /* Check RPKI Window Input Case 1 */
+  struct rpki_window rpki_windows[WINDOW_CMD_CNT];
+  int cnt = ARR_CNT(PARSING_WND_TESTCASE_1);
+  int j = generate_rpki_windows(rpki_windows, PARSING_WND_TESTCASE_1, cnt);
+  bgpstream_rpki_input_t *input = bgpstream_rpki_create_input();
+  int rst = bgpstream_rpki_parse_windows(input, rpki_windows, j);
+  CHECK_RPKI_RESULT("Parsing Window Input #1",
+        !strcmp(input->rpki_windows, PARSING_WND_TESTCASE_1_RST) && rst);
+  bgpstream_rpki_destroy_input(input);
+
+  /* Check RPKI Window Input Case 2 */
+  input = bgpstream_rpki_create_input();
+  cnt = ARR_CNT(PARSING_WND_TESTCASE_2);
+  j = generate_rpki_windows(rpki_windows, PARSING_WND_TESTCASE_2, cnt);
+  rst = bgpstream_rpki_parse_windows(input, rpki_windows, j);
+  CHECK_RPKI_RESULT("Parsing Window Input #2",
+        !strcmp(input->rpki_windows, PARSING_WND_TESTCASE_2_RST) && rst);
+  bgpstream_rpki_destroy_input(input);
+
+  return 0;
+}
+
+int test_rpki_validate() {
+
+  /* Declare BGPStream requirements */
+  int rrc = 0, counter = 0, erc = 0;
+  bgpstream_elem_t *bs_elem;
+  bgpstream_t *bs = bgpstream_create();
+  bgpstream_record_t *rec = NULL;
+  SETUP; CHECK_SET_INTERFACE(singlefile);
+  bgpstream_data_interface_option_t *option;
+  option = bgpstream_get_data_interface_option_by_name(bs, di_id, "upd-file");
+  bgpstream_set_data_interface_option(bs, option,
+                                      "ris.rrc06.updates.1427846400.gz");
+  bgpstream_start(bs);
+
+  /* Create an input instance for hitorical validation (CC01) */
+  bgpstream_rpki_input_t *input = bgpstream_rpki_create_input();
+  bgpstream_rpki_parse_collectors(VALIDATE_TESTCASE_1, input);
+
+  /* Create a RPKI window instance matching the testfile */
+  int VALIDATE_WND[2] = {1427846400, 1427846500};
+  struct rpki_window rpki_windows[WINDOW_CMD_CNT];
+  int j =
+      generate_rpki_windows(rpki_windows, VALIDATE_WND, ARR_CNT(VALIDATE_WND));
+  int rst = bgpstream_rpki_parse_windows(input, rpki_windows, j);
+  bgpstream_add_interval_filter(bs, rpki_windows[0].start, rpki_windows[0].end);
+
+  /* Set up a ROAFetchlib configuration */
+  rpki_cfg_t *cfg = bgpstream_rpki_set_cfg(input);
+  char val_result[VALIDATION_BUF];
+  char val_comp[VALIDATION_BUF];
+
+  /* Process every BGPStream elem and check the validation */
+  j = 0;
+  while ((rrc = bgpstream_get_next_record(bs, &rec)) > 0) {
+    if (rec->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
+      while ((erc = bgpstream_record_get_next_elem(rec, &bs_elem)) > 0) {
+        if (bs_elem->type == BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT) {
+          bs_elem->annotations.cfg = cfg;
+          bs_elem->annotations.rpki_active = input->rpki_active;
+          bs_elem->annotations.timestamp = rec->time_sec;
+          bgpstream_rpki_validate(bs_elem, val_result, sizeof(val_result));
+          snprintf(val_comp, sizeof(val_comp), "%s",
+                   VALIDATE_TESTCASE_1_RST[counter]);
+          if(check_val_result(val_result, val_comp, j++) != 0) {
+            return -1;
+          }
+          counter++;
+        }
+      }
+    }
+  }
+  return 0;
+}
+
+int main() {
+#ifdef WITH_RPKI
+  CHECK_RPKI_SECTION("RPKI Input", !test_rpki_create_input());
+  CHECK_RPKI_SECTION("RPKI Parsing", !test_rpki_parse_input());
+  CHECK_RPKI_SECTION("RPKI Window Parsing", !test_rpki_parse_windows());
+  CHECK_RPKI_SECTION("RPKI Validation", !test_rpki_validate());
+#endif
+  return 0;
+}

--- a/test/bgpstream-test-rpki.h
+++ b/test/bgpstream-test-rpki.h
@@ -1,0 +1,462 @@
+/*
+ * Copyright (C) 2014 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors:
+ *   Samir Al-Sheikh (s.al-sheikh@fu-berlin.de)
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <wandio.h>
+
+#define RESULT_LEN 40
+
+#define sep "--------------------------------------------------------"         \
+
+#define CHECK_RPKI_SECTION(name, check)                                        \
+  do {                                                                         \
+    int s = RESULT_LEN - strlen("Test-Section: ") - strlen(name);              \
+    int r = RESULT_LEN - strlen("Result for section ") - strlen(name);         \
+    fprintf(stderr, "* " sep "\n");                                            \
+    fprintf(stderr, "* %*c Test-Section: " name "\n", s/2, ' ');               \
+    fprintf(stderr, "* " sep "\n");                                            \
+    if (!(check)) {                                                            \
+      fprintf(stderr, "* " sep "\n");                                          \
+      fprintf(stderr, "* %*c Result for section " name ": FAILED\n", r/2, ' ');\
+      fprintf(stderr, "* " sep "\n");                                          \
+      return -1;                                                               \
+    } else {                                                                   \
+      fprintf(stderr, "* " sep "\n");                                          \
+      fprintf(stderr, "* %*c Result for section " name ": OK\n", r/2, ' ');    \
+      fprintf(stderr, "* " sep "\n\n");                                        \
+    }                                                                          \
+  } while (0)
+
+#define CHECK_RPKI_RESULT(test, check)                                         \
+  do {                                                                         \
+    int s = RESULT_LEN - strlen(test);                                         \
+    if (!(check)) {                                                            \
+      fprintf(stderr, "*   Test: %s ... %*c FAILED\n", test, s, ' ');          \
+      return -1;                                                               \
+    }                                                                          \
+    fprintf(stderr, "*   Test: %s ... %*c OK\n", test, s, ' ');                \
+  } while (0)
+
+#define SETUP                                                                  \
+  do {                                                                         \
+    bs = bgpstream_create();                                                   \
+  } while (0)
+
+#define CHECK_SET_INTERFACE(interface)                                         \
+  do {                                                                         \
+    di_id = bgpstream_get_data_interface_id_by_name(bs, STR(interface));       \
+    bgpstream_set_data_interface(bs, di_id);                                   \
+  } while (0)
+
+#define VALIDATION_BUF 2048
+
+/** Test-Section: RPKI Parsing */
+#define PARSING_SSH_TESTCASE_1 "user,host_key,private_key"
+#define PARSING_PCC_TESTCASE_1 "FU-Berlin:*;HAW:*"
+
+/** Test-Section: RPKI Window Parsing */
+#define PARSING_WND_TESTCASE_1                                                 \
+  (const uint32_t[6]) {                                                        \
+    1506816000, 1506816000, 1506817000, 1506817100, 1506818000, 1506818100     \
+  }
+
+#define PARSING_WND_TESTCASE_1_RST                                             \
+  "1506816000-1506816000,1506817000-1506817100,"                               \
+  "1506818000-1506818100"
+
+#define PARSING_WND_TESTCASE_2                                                 \
+  (const uint32_t[24]) {                                                       \
+    1506816000, 1506816100, 1506817000, 1506817100, 1506818000, 1506818100,    \
+        1506819000, 1506819100, 1506820000, 1506812100, 1506821000,            \
+        1506821100, 1506822000, 1506822100, 1506823000, 1506823100,            \
+        1506824000, 1506824100, 1506825000, 1506825100, 1506826000,            \
+        1506826100, 1506827000, 1506827100                                     \
+  }
+
+#define PARSING_WND_TESTCASE_2_RST                                             \
+  "1506816000-1506816100,1506817000-1506817100,"                               \
+  "1506818000-1506818100,1506819000-1506819100,"                               \
+  "1506820000-1506812100,1506821000-1506821100,"                               \
+  "1506822000-1506822100,1506823000-1506823100,"                               \
+  "1506824000-1506824100,1506825000-1506825100,"                               \
+  "1506826000-1506826100,1506827000-1506827100"
+
+/** Test-Section: RPKI Validation */
+#define VALIDATE_TESTCASE_1 "FU-Berlin:CC01"
+#define VALIDATE_TESTCASE_1_RST                                                \
+  (const char * [517]) {                                                       \
+    "FU-Berlin,CC01,notfound;",                                                \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,84.205.73.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe10::/48-48;",                   \
+        "FU-Berlin,CC01,valid,12654,84.205.66.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:ff02::/48-48;",                   \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:ff02::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:ff02::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,50530,2a00:1ce0::/32-48;",                       \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,47524,176.240.0.0/16-24;",                       \
+        "FU-Berlin,CC01,valid,12654,84.205.78.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe0e::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,84.205.77.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,12654,84.205.77.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,47524,176.240.0.0/16-24;",                       \
+        "FU-Berlin,CC01,valid,12654,84.205.67.0/24-24;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,47524,176.240.0.0/16-24;",                       \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,84.205.79.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,27891,2800:a020::/32-32;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe05::/48-48;",                   \
+        "FU-Berlin,CC01,valid,12654,84.205.69.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,47524,176.240.0.0/16-24;",                       \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,47524,176.240.0.0/16-24;",                       \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe0a::/48-48;",                   \
+        "FU-Berlin,CC01,valid,12654,84.205.74.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;"                        \
+        "FU-Berlin,CC01,valid,27891,150.187.178.0/24-24;",                     \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27686,150.186.112.0/20-20;"                      \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;",                       \
+        "FU-Berlin,CC01,valid,20312,150.185.0.0/16-20;"                        \
+        "FU-Berlin,CC01,valid,27807,150.185.0.0/16-16;"                        \
+        "FU-Berlin,CC01,valid,27892,150.185.192.0/24-24;",                     \
+        "FU-Berlin,CC01,valid,20312,150.185.0.0/16-20;"                        \
+        "FU-Berlin,CC01,valid,27807,150.185.0.0/16-16;"                        \
+        "FU-Berlin,CC01,valid,27892,150.185.222.0/24-24;",                     \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,invalid,17287,150.186.32.0/19-19;"                     \
+        "FU-Berlin,CC01,invalid,20312,150.186.0.0/15-19;"                      \
+        "FU-Berlin,CC01,invalid,27807,150.186.0.0/15-16;",                     \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,47524,176.240.0.0/16-24;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;"                        \
+        "FU-Berlin,CC01,valid,27890,150.186.64.0/19-19;",                      \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;"                        \
+        "FU-Berlin,CC01,valid,27891,150.187.142.0/24-24;",                     \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;"                        \
+        "FU-Berlin,CC01,valid,27891,150.187.145.0/24-24;",                     \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;"                        \
+        "FU-Berlin,CC01,valid,27891,150.187.141.0/24-24;",                     \
+        "FU-Berlin,CC01,valid,27891,190.168.192.0/18-18;",                     \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;"                        \
+        "FU-Berlin,CC01,valid,27891,150.187.148.0/24-24;",                     \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,20312,150.185.0.0/16-20;"                        \
+        "FU-Berlin,CC01,valid,23007,150.185.128.0/18-18;"                      \
+        "FU-Berlin,CC01,valid,27807,150.185.0.0/16-16;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,47524,176.240.0.0/16-24;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,31078,2a00:1328::/32-36;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe03::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe03::/48-48;",                   \
+        "FU-Berlin,CC01,valid,12654,84.205.67.0/24-24;",                       \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,84.205.67.0/24-24;",                       \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe03::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,27820,2800:130::/32-32;",                        \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:ff02::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,12654,84.205.64.0/24-24;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,60822,46.23.192.0/21-21;",                       \
+        "FU-Berlin,CC01,valid,60822,195.137.144.0/22-22;",                     \
+        "FU-Berlin,CC01,valid,60822,185.85.212.0/22-22;",                      \
+        "FU-Berlin,CC01,valid,60822,46.23.204.0/22-22;",                       \
+        "FU-Berlin,CC01,valid,60822,46.23.200.0/22-22;",                       \
+        "FU-Berlin,CC01,valid,60822,46.23.192.0/21-21;",                       \
+        "FU-Berlin,CC01,valid,60822,195.137.144.0/22-22;",                     \
+        "FU-Berlin,CC01,valid,60822,185.85.212.0/22-22;",                      \
+        "FU-Berlin,CC01,valid,60822,46.23.204.0/22-22;",                       \
+        "FU-Berlin,CC01,valid,60822,46.23.200.0/22-22;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,60822,46.23.192.0/21-21;",                       \
+        "FU-Berlin,CC01,valid,60822,195.137.144.0/22-22;",                     \
+        "FU-Berlin,CC01,valid,60822,185.85.212.0/22-22;",                      \
+        "FU-Berlin,CC01,valid,60822,46.23.204.0/22-22;",                       \
+        "FU-Berlin,CC01,valid,60822,46.23.200.0/22-22;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,27820,2800:130::/32-32;",                        \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,20312,150.185.0.0/16-20;"                        \
+        "FU-Berlin,CC01,valid,27807,150.185.0.0/16-16;",                       \
+        "FU-Berlin,CC01,valid,20312,150.188.0.0/15-24;"                        \
+        "FU-Berlin,CC01,valid,27807,150.188.0.0/15-16;",                       \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;",                       \
+        "FU-Berlin,CC01,valid,20312,150.186.0.0/15-19;"                        \
+        "FU-Berlin,CC01,valid,27807,150.186.0.0/15-16;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,47524,176.240.0.0/16-24;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,31078,2a00:1328::/32-36;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,31078,2a00:1328::/32-36;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,31078,2a00:1328::/32-36;",                       \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe00::/48-48;",                   \
+        "FU-Berlin,CC01,valid,10091,2404:e800::/31-64;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,18747,190.60.0.0/15-24;",                        \
+        "FU-Berlin,CC01,valid,18747,190.60.0.0/15-24;",                        \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:fe00::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:ff02::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,valid,60822,46.23.192.0/21-21;",                       \
+        "FU-Berlin,CC01,valid,60822,195.137.144.0/22-22;",                     \
+        "FU-Berlin,CC01,valid,60822,185.85.212.0/22-22;",                      \
+        "FU-Berlin,CC01,valid,60822,46.23.204.0/22-22;",                       \
+        "FU-Berlin,CC01,valid,60822,46.23.200.0/22-22;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,12654,84.205.64.0/24-24;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,10091,2404:e800::/31-64;",                       \
+        "FU-Berlin,CC01,valid,12654,2001:7fb:ff02::/48-48;",                   \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,12654,84.205.64.0/24-24;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,27820,2800:130::/32-32;",                        \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,35226,2a02:2158::/32-32;",                       \
+        "FU-Berlin,CC01,valid,31078,2a00:1328::/32-36;",                       \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,valid,201565,185.11.232.0/22-22;",                     \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;",                                            \
+        "FU-Berlin,CC01,invalid,9050,188.214.141.0/24-24;",                    \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;",                \
+        "FU-Berlin,CC01,notfound;", "FU-Berlin,CC01,notfound;"                 \
+  }

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -39,6 +39,9 @@
 #include <time.h>
 #include <unistd.h>
 #include <unistd.h>
+#ifdef WITH_RPKI
+#include "utils/bgpstream_utils_rpki.h"
+#endif
 #include "bgpstream.h"
 #include "getopt.h"
 #include "utils.h"
@@ -125,6 +128,17 @@
         "print format information before output" },                            \
     { { "version", no_argument, 0, 'v'},"", "print the version of bgpreader" },\
     { { "help", no_argument, 0, 'h'}, "", "print this help menu" },            \
+    { { "rpki", no_argument, 0, 504}, "", "validate the BGP records with "     \
+        "historical RPKI dumps (default collector)" },                         \
+    { { "rpki-live", no_argument, 0, 502}, "", "validate the BGP records with" \
+        " the current RPKI dump (default collector)" },                        \
+    { { "rpki-collectors", required_argument, 0, 501},                         \
+        "<((*|project):(*|(collector(,collectors)*))(;)?)*>","\nspecify the "  \
+        "collectors used for (historical or live) RPKI validation " },         \
+    { { "rpki-unified", no_argument, 0, 503}, "",                              \
+        "whether the RPKI validation for different collectors is unified" },   \
+    { { "rpki-ssh", required_argument, 0, 500}, "<user,hostkey,private key>",  \
+        "\nenable SSH encryption for the live connection to the RTR server" }, \
     { { "help", no_argument, 0, '?'},  "", "print this help menu" },           \
     { { 0, 0, 0, 0 }, "", "" }                                                 \
   }
@@ -211,8 +225,10 @@ static void usage()
       fprintf(stderr, " -%c, --%-23s%-15s  %s\n", OPTIONS[k].option.val,
               OPTIONS[k].option.name, OPTIONS[k].usage, expl_buf);
     } else {
+#ifdef WITH_RPKI
       fprintf(stderr, "     --%-23s%-15s  %s\n", OPTIONS[k].option.name,
               OPTIONS[k].usage, expl_buf);
+#endif
     }
     if(OPTIONS[k].option.val == 'd') {
       data_if_usage();
@@ -260,6 +276,11 @@ int main(int argc, char *argv[])
   char *interface_options[OPTION_CMD_CNT];
   int interface_options_cnt = 0;
 
+#ifdef WITH_RPKI
+  struct rpki_window rpki_windows[WINDOW_CMD_CNT];
+  bgpstream_rpki_input_t *rpki_input = bgpstream_rpki_create_input();
+#endif
+
   char *filterstring = NULL;
   char *intervalstring = NULL;
 
@@ -293,8 +314,10 @@ int main(int argc, char *argv[])
   int k;
   for (k = 0; k < OPTIONS_CNT; k++) {
     size_t size = strlen(short_options);
-    snprintf(short_options + size, sizeof(short_options) - size,
-             OPTIONS[k].option.has_arg ? "%c:": "%c", OPTIONS[k].option.val);
+    if(isalpha(OPTIONS[k].option.val)) {
+      snprintf(short_options + size, sizeof(short_options) - size,
+               OPTIONS[k].option.has_arg ? "%c:": "%c", OPTIONS[k].option.val);
+    }
     long_options[k] = OPTIONS[k].option;
   }
   long_options[k] = OPTIONS[k].option;
@@ -446,6 +469,23 @@ int main(int argc, char *argv[])
       usage();
       goto done;
       break;
+#ifdef WITH_RPKI
+    case 500:
+      bgpstream_rpki_parse_ssh(optarg, rpki_input);
+      break;
+    case 501:
+      bgpstream_rpki_parse_collectors(optarg, rpki_input);
+      break;
+    case 502:
+      bgpstream_rpki_parse_live(rpki_input);
+      break;
+    case 503:
+      bgpstream_rpki_parse_unified(rpki_input);
+      break;
+    case 504:
+      bgpstream_rpki_parse_default(rpki_input);
+      break;
+#endif
     default:
       usage();
       goto err;
@@ -593,6 +633,18 @@ int main(int argc, char *argv[])
   int rrc = 0, erc = 0, rec_cnt = 0;
   bgpstream_elem_t *bs_elem;
 
+#ifdef WITH_RPKI
+  rpki_cfg_t *cfg = NULL;
+  if(rpki_input != NULL && rpki_input->rpki_active){
+    memcpy(&rpki_windows, &windows, sizeof(rpki_windows));
+    if(!bgpstream_rpki_parse_windows(rpki_input, rpki_windows, windows_cnt)) {
+      fprintf(stderr, "ERROR: Could not parse BGPStream windows\n");
+      goto err;
+    }
+    cfg = bgpstream_rpki_set_cfg(rpki_input);
+  }
+#endif
+
   while ((rrc = bgpstream_get_next_record(bs, &bs_record)) > 0 &&
          (rec_limit < 0 || rec_cnt < rec_limit)) {
     rec_cnt++;
@@ -619,6 +671,13 @@ int main(int argc, char *argv[])
       }
 
       while ((erc = bgpstream_record_get_next_elem(bs_record, &bs_elem)) > 0) {
+#ifdef WITH_RPKI
+        if(rpki_input != NULL && rpki_input->rpki_active){
+          bs_elem->annotations.cfg = cfg;
+          bs_elem->annotations.rpki_active = rpki_input->rpki_active;
+          bs_elem->annotations.timestamp = bs_record->time_sec;            
+        }
+#endif
         if (print_elem(bs_record, bs_elem) != 0) {
           goto err;
         }
@@ -640,6 +699,13 @@ int main(int argc, char *argv[])
     goto err;
   }
 
+#ifdef WITH_RPKI
+  if(rpki_input != NULL && rpki_input->rpki_active){
+    bgpstream_rpki_destroy_cfg(cfg);
+    bgpstream_rpki_destroy_input(rpki_input);
+  }
+#endif
+
  done:
   /* deallocate memory for interface */
   bgpstream_destroy(bs);
@@ -647,6 +713,12 @@ int main(int argc, char *argv[])
 
 err:
   bgpstream_destroy(bs);
+#ifdef WITH_RPKI
+  if(rpki_input != NULL && rpki_input->rpki_active){
+    bgpstream_rpki_destroy_cfg(cfg);
+    bgpstream_rpki_destroy_input(rpki_input);
+  }
+#endif
   return -1;
 }
 

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -128,16 +128,17 @@
         "print format information before output" },                            \
     { { "version", no_argument, 0, 'v'},"", "print the version of bgpreader" },\
     { { "help", no_argument, 0, 'h'}, "", "print this help menu" },            \
-    { { "rpki", no_argument, 0, 504}, "", "validate the BGP records with "     \
-        "historical RPKI dumps (default collector)" },                         \
-    { { "rpki-live", no_argument, 0, 502}, "", "validate the BGP records with" \
-        " the current RPKI dump (default collector)" },                        \
-    { { "rpki-collectors", required_argument, 0, 501},                         \
+    { { "rpki", no_argument, 0, RPKI_OPTION_DEFAULT}, "", "validate the BGP "  \
+        "records with historical RPKI dumps (default collector)" },            \
+    { { "rpki-live", no_argument, 0, RPKI_OPTION_LIVE}, "", "validate the BGP "\
+        " records with the current RPKI dump (default collector)" },           \
+    { { "rpki-collectors", required_argument, 0, RPKI_OPTION_COLLECTORS},      \
         "<((*|project):(*|(collector(,collectors)*))(;)?)*>","\nspecify the "  \
         "collectors used for (historical or live) RPKI validation " },         \
-    { { "rpki-unified", no_argument, 0, 503}, "",                              \
+    { { "rpki-unified", no_argument, 0, RPKI_OPTION_UNIFIED}, "",              \
         "whether the RPKI validation for different collectors is unified" },   \
-    { { "rpki-ssh", required_argument, 0, 500}, "<user,hostkey,private key>",  \
+    { { "rpki-ssh", required_argument, 0, RPKI_OPTION_SSH},                    \
+        "<user,hostkey,private key>",                                          \
         "\nenable SSH encryption for the live connection to the RTR server" }, \
     { { "help", no_argument, 0, '?'},  "", "print this help menu" },           \
     { { 0, 0, 0, 0 }, "", "" }                                                 \
@@ -149,6 +150,14 @@ struct options{
   struct option option;
   char* usage;
   char* expl;
+};
+
+enum rpki_options {
+  RPKI_OPTION_SSH = 500,
+  RPKI_OPTION_COLLECTORS = 501,
+  RPKI_OPTION_LIVE = 502,
+  RPKI_OPTION_UNIFIED = 503,
+  RPKI_OPTION_DEFAULT = 504
 };
 
 static struct option long_options [OPTIONS_CNT + 1];
@@ -470,19 +479,19 @@ int main(int argc, char *argv[])
       goto done;
       break;
 #ifdef WITH_RPKI
-    case 500:
+    case RPKI_OPTION_SSH:
       bgpstream_rpki_parse_ssh(optarg, rpki_input);
       break;
-    case 501:
+    case RPKI_OPTION_COLLECTORS:
       bgpstream_rpki_parse_collectors(optarg, rpki_input);
       break;
-    case 502:
+    case RPKI_OPTION_LIVE:
       bgpstream_rpki_parse_live(rpki_input);
       break;
-    case 503:
+    case RPKI_OPTION_UNIFIED:
       bgpstream_rpki_parse_unified(rpki_input);
       break;
-    case 504:
+    case RPKI_OPTION_DEFAULT:
       bgpstream_rpki_parse_default(rpki_input);
       break;
 #endif


### PR DESCRIPTION
- The configure script checks whether the shared library is available or not and supports the option ```—without-rpki```

- The BGPReader accepts multiple new parameters which allows setting all RPKI options:
  * ```--rpki``` enables the historical RPKI validation with default collector (standalone)

  * ```--rpki-live``` enables the live RPKI validation with a default RTR-Server (standlone)

  * ```--rpki-collectors``` specifies the collectors used for the RPKI validation (standalone), <br /> Format: "((\*|project):(\*|(collector(,collectors)*))(;)?)*", <br /> e.g. "PJ_1:CC_1,CC_11;PJ_2:CC_2" or "PJ_1:*;PJ_2:CC_2" or "\*:\*"

  * ```--rpki-unified``` enables an unified validation where the ROA dumps of the different collectors are combined

  * ```--rpki-ssh``` enables SSH encryption to the RTR Server, format: "username, hostkey_path, privatekey_path"

- On basis of the parameters the BGPReader creates the ROAFetchlib configuration which is needed for the validation process and stores it in every BGP elem instance

- During the output process every BGP elem will be validated and the validation result is added to the regular BGPReader output