### PR TITLE
remove unused variables to resolve warnings

### DIFF
--- a/lib/formats/bs_format_ripejson.c
+++ b/lib/formats/bs_format_ripejson.c
@@ -414,8 +414,8 @@ static bgpstream_format_status_t bs_format_process_json_fields(bgpstream_format_
   int r;
   bgpstream_format_status_t rc;
   jsmn_parser p;
-  char* key_ptr, *value_ptr, *next_ptr;
-  size_t key_size, value_size;
+  char *value_ptr, *next_ptr;
+  size_t value_size;
 
   jsmntok_t *t;
   size_t tokcount = 128;
@@ -455,8 +455,6 @@ again:
 
   /* Loop over all fields of the json string buffer */
   for (i = 1; i < r-1; i++) {
-    key_ptr = STATE->json_string_buffer + t[i].start;
-    key_size = t[i].end-t[i].start;
     value_ptr = STATE->json_string_buffer + t[i+1].start;
     value_size = t[i+1].end-t[i+1].start;
 


### PR DESCRIPTION
This should address the warning below:
```
bs_format_ripejson.c: In function 'bs_format_process_json_fields':
bs_format_ripejson.c:418:10: error: variable 'key_size' set but not used [-Werror=unused-but-set-variable]
  size_t key_size, value_size;
         ^
bs_format_ripejson.c:417:9: error: variable 'key_ptr' set but not used [-Werror=unused-but-set-variable]
  char* key_ptr, *value_ptr, *next_ptr;
        ^
cc1: all warnings being treated as errors
```

On MacOS the clang gcc version below does not have the warning:
```
$ gcc -v
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 9.1.0 (clang-902.0.39.2)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```