### PR TITLE
fix files included in distribution for tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,13 +32,6 @@ SUBDIRS = common	\
 
 AM_CPPFLAGS =
 
-EXTRA_DIST = 	test/sqlite_test.db \
-		test/csv_test.csv \
-		test/routeviews.route-views.jinx.ribs.1427846400.bz2 \
-		test/routeviews.route-views.jinx.updates.1427846400.bz2 \
-		test/ris.rrc06.updates.1427846400.gz \
-		test/ris.rrc06.ribs.1427846400.gz
-
 include_HEADERS =
 
 ACLOCAL_AMFLAGS = -I m4

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -54,16 +54,25 @@ check_PROGRAMS =  			\
 	bgpstream-test-utils-patricia  \
   $(RPKI_TEST)
 
+# test data files
+EXTRA_DIST = 	sqlite_test.db \
+		csv_test.csv \
+		ris-live-stream.json \
+		routeviews.route-views.jinx.ribs.1427846400.bz2 \
+		routeviews.route-views.jinx.updates.1427846400.bz2 \
+		ris.rrc06.updates.1427846400.gz \
+		ris.rrc06.ribs.1427846400.gz
+
 bgpstream_test_SOURCES = bgpstream-test.c bgpstream_test.h
 bgpstream_test_LDADD   = $(top_builddir)/lib/libbgpstream.la
 
 bgpstream_test_filters_SOURCES = bgpstream-test-filters.c bgpstream_test.h
 bgpstream_test_filters_LDADD   = $(top_builddir)/lib/libbgpstream.la
 
-bgpstream_test_ripejson_SOURCES = bgpstream-test-ripejson.c bgpstream_test.h
+bgpstream_test_ripejson_SOURCES = bgpstream-test-ripejson.c bgpstream-test-ripejson.h bgpstream_test.h
 bgpstream_test_ripejson_LDADD   = $(top_builddir)/lib/libbgpstream.la
 
-bgpstream_test_rpki_SOURCES = bgpstream-test-rpki.c bgpstream_test.h
+bgpstream_test_rpki_SOURCES = bgpstream-test-rpki.c bgpstream-test-rpki.h bgpstream_test.h
 bgpstream_test_rpki_LDADD   = $(top_builddir)/lib/libbgpstream.la
 
 bgpstream_test_utils_addr_SOURCES = bgpstream-test-utils-addr.c bgpstream_test.h


### PR DESCRIPTION
- move the test datasets include definitions from `Makefile.am` to `test/Makefile.am`
- include corresponding header files needed by ripejson and rpki tests
- include datafile needed by ripejson