### PR TITLE
Add configure option to disable libparsebgp warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,25 @@ AM_CONDITIONAL(HAS_DOXYGEN, [test x"$bgpstream_doxygen" = xyes])
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([---- BGPStream configuration ----])
 
+AC_MSG_NOTICE([checking format modules...])
+
+# allow libparsebgp warnings to be silenced
+AC_MSG_CHECKING([whether to silence libparsebgp warnings])
+   AC_ARG_ENABLE([parser-warnings],
+       [AS_HELP_STRING([--disable-parser-warnings],
+               [disable BGP parse warnings (def=no)])],
+               [enable_parser_warnings="$enableval"],
+               [enable_parser_warnings=yes])
+   if test x"$enable_parser_warnings" != x"no"; then
+      disable_parser_warnings="no"
+   else
+      disable_parser_warnings="yes"
+   fi
+   AC_MSG_RESULT([$disable_parser_warnings])
+   if test x"$disable_parser_warnings" == x"yes"; then
+      AC_DEFINE([PARSEBGP_SILENCE_WARNING],[],[Disable parsebgp warnings])
+   fi
+
 AC_MSG_NOTICE([checking transport modules...])
 
 # shall we build with support for the kafka transport module?

--- a/lib/formats/bgpstream_parsebgp_common.c
+++ b/lib/formats/bgpstream_parsebgp_common.c
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
 #include "bgpstream_parsebgp_common.h"
 #include "bgpstream_format_interface.h"
 #include "bgpstream_record_int.h"
@@ -678,5 +679,8 @@ void bgpstream_parsebgp_opts_init(parsebgp_opts_t *opts)
 
   opts->ignore_not_implemented = 1;
   opts->ignore_invalid = 1;
-  // TODO: allow user to silence parsebgp warnings at compile time
+
+#ifdef PARSEBGP_SILENCE_WARNING
+  opts->silence_not_implemented = 1;
+#endif
 }


### PR DESCRIPTION
We currently have the parser configured to log any parse failures to aid with debugging the v2 beta, but these can be annoying, so this allows advanced users to disable the warnings.

Run configure with the `--disable-parser-warnings` option to disable the parser warnings.