### PR TITLE
Ensure that the record-type option is valid

### DIFF
--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -400,6 +400,12 @@ int main(int argc, char *argv[])
         usage();
         goto err;
       }
+      if (strcmp(optarg, "ribs") != 0 && strcmp(optarg, "updates") != 0) {
+        fprintf(stderr,
+                "ERROR: record-type must be one of \"ribs\" or \"updates\"\n");
+        usage();
+        goto err;
+      }
       types[types_cnt++] = strdup(optarg);
       break;
     case 'w':


### PR DESCRIPTION
The only (currently) valid options are `ribs` and `updates`.