### PR TITLE
new data interface `betarislive`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,12 +236,6 @@ if test "x$with_di_betabmp" == xyes; then
    fi
 fi
 
-if test "x$with_di_betarislive" == xyes; then
-   if test x"$with_transport_kafka" != xyes; then
-      AC_MSG_ERROR([(Beta) BMP Stream data interface requires Kafka transport module (--without-betarislive to disable)])
-   fi
-fi
-
 if test "x$with_di_sqlite" == xyes; then
    # check for sqlite library
    AC_CHECK_LIB([sqlite3], [sqlite3_open_v2], ,

--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,7 @@ BS_WITH_DI([bgpstream_broker],[broker],[BROKER],[yes])
 BS_WITH_DI([bgpstream_singlefile],[singlefile],[SINGLEFILE],[yes])
 BS_WITH_DI([bgpstream_kafka],[kafka],[KAFKA],[yes])
 BS_WITH_DI([bgpstream_betabmp],[betabmp],[BETABMP],[yes])
+BS_WITH_DI([bgpstream_betarislive],[betarislive],[BETARISLIVE],[yes])
 BS_WITH_DI([bgpstream_csvfile],[csvfile],[CSVFILE],[yes])
 BS_WITH_DI([bgpstream_sqlite],[sqlite],[SQLITE],[no])
 
@@ -232,6 +233,12 @@ fi
 if test "x$with_di_betabmp" == xyes; then
    if test x"$with_transport_kafka" != xyes; then
       AC_MSG_ERROR([(Beta) BMP Stream data interface requires Kafka transport module (--without-betabmp to disable)])
+   fi
+fi
+
+if test "x$with_di_betarislive" == xyes; then
+   if test x"$with_transport_kafka" != xyes; then
+      AC_MSG_ERROR([(Beta) BMP Stream data interface requires Kafka transport module (--without-betarislive to disable)])
    fi
 fi
 

--- a/lib/bgpstream.h
+++ b/lib/bgpstream.h
@@ -148,6 +148,9 @@ typedef enum {
   /** (Beta) BMP Stream interface */
   BGPSTREAM_DATA_INTERFACE_BETABMP,
 
+  /** (Beta) RISLIVE Stream interface */
+  BGPSTREAM_DATA_INTERFACE_BETARISLIVE,
+
   /** The number of data interfaces */
   _BGPSTREAM_DATA_INTERFACE_CNT,
 

--- a/lib/bgpstream_di_mgr.c
+++ b/lib/bgpstream_di_mgr.c
@@ -61,6 +61,10 @@
 #include "bsdi_betabmp.h"
 #endif
 
+#ifdef WITH_DATA_INTERFACE_BETARISLIVE
+#include "bsdi_betarislive.h"
+#endif
+
 /* After 10 retries, start exponential backoff */
 #define DATA_INTERFACE_BLOCKING_RETRY_CNT 10
 /* Wait at least 20 seconds if the broker has no new data for us */
@@ -136,6 +140,12 @@ static const di_alloc_func_t di_alloc_functions[] = {
 
 #ifdef WITH_DATA_INTERFACE_BETABMP
   bsdi_betabmp_alloc,
+#else
+  NULL,
+#endif
+
+#ifdef WITH_DATA_INTERFACE_BETARISLIVE
+  bsdi_betarislive_alloc,
 #else
   NULL,
 #endif

--- a/lib/datainterfaces/Makefile.am
+++ b/lib/datainterfaces/Makefile.am
@@ -29,7 +29,7 @@ SUBDIRS=
 # to allow #include <config.h>
 AM_CPPFLAGS= 	-I$(top_srcdir) \
 		-I$(top_srcdir)/lib \
-                -I$(top_srcdir)/lib/utils \
+		-I$(top_srcdir)/lib/utils \
 	 	-I$(top_srcdir)/common
 
 
@@ -66,6 +66,11 @@ endif
 if WITH_DATA_INTERFACE_BETABMP
 DI_SOURCES+=bsdi_betabmp.c \
 	    bsdi_betabmp.h
+endif
+
+if WITH_DATA_INTERFACE_BETARISLIVE
+DI_SOURCES+=bsdi_betarislive.c \
+	    bsdi_betarislive.h
 endif
 
 libbgpstream_data_interfaces_la_SOURCES = $(DI_SOURCES)

--- a/lib/datainterfaces/bsdi_betarislive.c
+++ b/lib/datainterfaces/bsdi_betarislive.c
@@ -193,5 +193,8 @@ int bsdi_betarislive_update_resources(bsdi_t *di)
   }
   assert(res != NULL);
 
+  bgpstream_log(BGPSTREAM_LOG_INFO,
+                "start streaming from %s",STATE->url);
+
   return 0;
 }

--- a/lib/datainterfaces/bsdi_betarislive.c
+++ b/lib/datainterfaces/bsdi_betarislive.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2017 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "bsdi_betarislive.h"
+#include "bgpstream_log.h"
+#include "config.h"
+#include "utils.h"
+#include <assert.h>
+#include <inttypes.h>
+#include <string.h>
+#include <wandio.h>
+
+#define STATE (BSDI_GET_STATE(di, betarislive))
+
+#define FIREHOSE_URL "https://ris-live.ripe.net/v1/stream/?format=json"
+#define DEFAULT_CLIENT "libbgpstream-default"
+
+/* ---------- START CLASS DEFINITION ---------- */
+
+/* define the options this data interface accepts */
+static bgpstream_data_interface_option_t options[] = {
+  /* Firehose Client */
+  {
+    BGPSTREAM_DATA_INTERFACE_BETARISLIVE, // interface ID
+    OPTION_CLIENT,                   // internal ID
+    "client",                        // name
+    "client name for RIS-Live firehose stream (default: " DEFAULT_CLIENT ")",
+  },
+};
+
+/* create the class structure for this data interface */
+BSDI_CREATE_CLASS_FULL(
+  betarislive, "beta-rislive-stream", BGPSTREAM_DATA_INTERFACE_BETARISLIVE,
+  "Read updates in real-time from the RIPE RIS live stream (BETA)",
+  options);
+
+/* ---------- END CLASS DEFINITION ---------- */
+
+typedef struct bsdi_betarislive_state {
+  /* user-provided options: */
+
+  // RIS live firehose client name
+  char *client_name;
+
+  // RIS live firehose full url
+  char *url;
+
+  // we only ever yield one resource
+  int done;
+
+} bsdi_betabmp_state_t;
+
+/* ========== PRIVATE METHODS BELOW HERE ========== */
+
+static int build_url()
+{
+  size_t needed = snprintf(NULL, 0, "%s&client=%s", FIREHOSE_URL, STATE->client_name) + 1;
+  STATE->url = malloc(needed);
+  int written = sprintf(STATE->url, "%s&client=%s", FIREHOSE_URL, STATE->client_name);
+  if(needed != written+1){
+    return -1;
+  }
+  return 0;
+}
+
+
+/* ========== PUBLIC METHODS BELOW HERE ========== */
+
+int bsdi_betarislive_init(bsdi_t *di)
+{
+  bsdi_betarislive_state_t *state;
+
+  if ((state = malloc_zero(sizeof(bsdi_betarislive_state_t))) == NULL) {
+    goto err;
+  }
+  BSDI_SET_STATE(di, state);
+
+  return 0;
+
+err:
+  bsdi_betarislive_destroy(di);
+  return -1;
+}
+
+int bsdi_betarislive_start(bsdi_t *di)
+{
+  // our defaults are sufficient to run
+  return 0;
+}
+
+int bsdi_betarislive_set_option(
+  bsdi_t *di, const bgpstream_data_interface_option_t *option_type,
+  const char *option_value)
+{
+  int i;
+  int found = 0;
+
+  switch (option_type->id) {
+  case OPTION_CLIENT:
+    free(STATE->client_name);
+    if ((STATE->client_name = strdup(option_value)) == NULL) {
+      return -1;
+    }
+    break;
+
+  default:
+    return -1;
+  }
+
+  if(STATE->client_name == NULL){
+    // assign default client name
+    if((STATE->client_name = strdup(DEFAUL_CLIENT)) == NULL){
+      bgpstream_log(BGPSTREAM_LOG_ERR,
+                    "Could not assign default ris-live firehose client.");
+      return -1;
+    }
+  }
+
+  if(build_url()!=0){
+    return -1;
+  }
+
+  return 0;
+}
+
+void bsdi_betarislive_destroy(bsdi_t *di)
+{
+  if (di == NULL || STATE == NULL) {
+    return;
+  }
+
+  free(STATE->client_name);
+  STATE->client_name = NULL;
+
+  free(STATE->url);
+  STATE->url = NULL;
+
+  free(STATE);
+  BSDI_SET_STATE(di, NULL);
+}
+
+int bsdi_betarislive_update_resources(bsdi_t *di)
+{
+  int rc;
+  bgpstream_resource_t *res = NULL;
+
+  // we only ever yield one resource
+  if (STATE->done != 0) {
+    return 0;
+  }
+  STATE->done = 1;
+
+  // we treat kafka as having data from <recent> to <forever>
+  if ((rc = bgpstream_resource_mgr_push(
+         BSDI_GET_RES_MGR(di), BGPSTREAM_RESOURCE_TRANSPORT_KAFKA,
+         BGPSTREAM_RESOURCE_FORMAT_RIPEJSON, STATE->url,
+         0, // indicate we don't know how much historical data there is
+         BGPSTREAM_FOREVER, // indicate that the resource is a "stream"
+         "ris-live",   // fix our project to "caida"
+         "", // leave collector unset since we'll get it from openbmp hdrs
+         BGPSTREAM_UPDATE, //
+         &res)) <= 0) {
+    return rc;
+  }
+  assert(res != NULL);
+
+  return 0;
+}

--- a/lib/datainterfaces/bsdi_betarislive.c
+++ b/lib/datainterfaces/bsdi_betarislive.c
@@ -180,7 +180,7 @@ int bsdi_betarislive_update_resources(bsdi_t *di)
 
   // we treat kafka as having data from <recent> to <forever>
   if ((rc = bgpstream_resource_mgr_push(
-         BSDI_GET_RES_MGR(di), BGPSTREAM_RESOURCE_TRANSPORT_KAFKA,
+         BSDI_GET_RES_MGR(di), BGPSTREAM_RESOURCE_TRANSPORT_FILE,
          BGPSTREAM_RESOURCE_FORMAT_RIPEJSON, STATE->url,
          0, // indicate we don't know how much historical data there is
          BGPSTREAM_FOREVER, // indicate that the resource is a "stream"

--- a/lib/datainterfaces/bsdi_betarislive.c
+++ b/lib/datainterfaces/bsdi_betarislive.c
@@ -50,8 +50,8 @@ static bgpstream_data_interface_option_t options[] = {
   /* Firehose Client */
   {
     BGPSTREAM_DATA_INTERFACE_BETARISLIVE, // interface ID
-    OPTION_CLIENT,                   // internal ID
-    "client",                        // name
+    OPTION_CLIENT,                        // internal ID
+    "client",                             // client name
     "client name for RIS-Live firehose stream (default: " DEFAULT_CLIENT ")",
   },
 };
@@ -179,15 +179,14 @@ int bsdi_betarislive_update_resources(bsdi_t *di)
     return -1;
   }
 
-  // we treat kafka as having data from <recent> to <forever>
   if ((rc = bgpstream_resource_mgr_push(
          BSDI_GET_RES_MGR(di), BGPSTREAM_RESOURCE_TRANSPORT_FILE,
          BGPSTREAM_RESOURCE_FORMAT_RIPEJSON, STATE->url,
-         0, // indicate we don't know how much historical data there is
-         BGPSTREAM_FOREVER, // indicate that the resource is a "stream"
-         "ris-live",   // fix our project to "caida"
-         "", // leave collector unset
-         BGPSTREAM_UPDATE, //
+         0,                   // indicate we don't know how much historical data there is
+         BGPSTREAM_FOREVER,   // indicate that the resource is a "stream"
+         "ris-live",          // fix project name to "ris-live"
+         "",                  // leave collector unset
+         BGPSTREAM_UPDATE,
          &res)) <= 0) {
     return rc;
   }

--- a/lib/datainterfaces/bsdi_betarislive.h
+++ b/lib/datainterfaces/bsdi_betarislive.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 The Regents of the University of California.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __BSDI_BETARISLIVE_H
+#define __BSDI_BETARISLIVE_H
+
+#include "bgpstream_di_interface.h"
+
+BSDI_GENERATE_PROTOS(betarislive);
+
+#endif /* __BSDI_BETARISLIVE_H */


### PR DESCRIPTION
created an new data interface `betarislive` for streaming from RIPE RIS live stream.

- default firehose client name is `libbgpstream-default`
- added `client` option to specify the client name

Example commands:
- `./tools/bgpreader -d beta-ris-stream`
- `./tools/bgpreader -d beta-ris-stream -o client='test-client'`
