### PR TITLE
Fix issue where very-long message gets cut off due to limited buffer size

### DIFF
--- a/lib/bgpstream_transport.c
+++ b/lib/bgpstream_transport.c
@@ -120,7 +120,7 @@ void bgpstream_transport_destroy(bgpstream_transport_t *transport)
 }
 
 int64_t bgpstream_transport_readline(bgpstream_transport_t *transport,
-                                     void *buffer, int64_t len)
+                                     void *buffer, int64_t len, int chomp)
 {
-  return transport->readline(transport, buffer, len);
+  return transport->readline(transport, buffer, len, chomp);
 }

--- a/lib/bgpstream_transport.h
+++ b/lib/bgpstream_transport.h
@@ -58,7 +58,7 @@ int64_t bgpstream_transport_read(bgpstream_transport_t *transport, void *buffer,
  * @return the number of bytes read if successful, -1 otherwise
  */
 int64_t bgpstream_transport_readline(bgpstream_transport_t *transport,
-                                     void *buffer, int64_t len);
+                                     void *buffer, int64_t len, int chomp);
 
 /** Shutdown and destroy the given transport handler
  *

--- a/lib/bgpstream_transport_interface.h
+++ b/lib/bgpstream_transport_interface.h
@@ -52,7 +52,7 @@
   int64_t bs_transport_##name##_read(bgpstream_transport_t *t,                 \
                                      uint8_t *buffer, int64_t len);            \
   int64_t bs_transport_##name##_readline(bgpstream_transport_t *t,             \
-                                         uint8_t *buffer, int64_t len);        \
+                                         uint8_t *buffer, int64_t len, chomp); \
   void bs_transport_##name##_destroy(bgpstream_transport_t *t);
 
 #define BS_TRANSPORT_SET_METHODS(classname, transport)                         \
@@ -87,7 +87,7 @@ struct bgpstream_transport {
    * @return the number of bytes read if successful, -1 otherwise
    */
   int64_t (*readline)(struct bgpstream_transport *t, uint8_t *buffer,
-                      int64_t len);
+                      int64_t len, int chomp);
 
   /** Shutdown and free this data transport
    *

--- a/lib/bgpstream_transport_interface.h
+++ b/lib/bgpstream_transport_interface.h
@@ -52,7 +52,8 @@
   int64_t bs_transport_##name##_read(bgpstream_transport_t *t,                 \
                                      uint8_t *buffer, int64_t len);            \
   int64_t bs_transport_##name##_readline(bgpstream_transport_t *t,             \
-                                         uint8_t *buffer, int64_t len, chomp); \
+                                         uint8_t *buffer, int64_t len,         \
+                                         int chomp);                           \
   void bs_transport_##name##_destroy(bgpstream_transport_t *t);
 
 #define BS_TRANSPORT_SET_METHODS(classname, transport)                         \

--- a/lib/formats/bs_format_ripejson.c
+++ b/lib/formats/bs_format_ripejson.c
@@ -553,7 +553,7 @@ bs_format_ripejson_populate_record(bgpstream_format_t *format,
 
 retry:
   STATE->json_string_buffer_len = bgpstream_transport_readline(
-    format->transport, STATE->json_string_buffer, BGPSTREAM_PARSEBGP_BUFLEN);
+    format->transport, STATE->json_string_buffer, BGPSTREAM_PARSEBGP_BUFLEN, 0);
 
   assert(STATE->json_string_buffer_len < BGPSTREAM_PARSEBGP_BUFLEN);
 

--- a/lib/formats/bs_format_ripejson.c
+++ b/lib/formats/bs_format_ripejson.c
@@ -248,11 +248,10 @@ static int readline(bgpstream_format_t *format)
       buffer_ptr[current_read-1] == '\n'){
       // if read less than a full buffer, or last byte is an newline, readline is finished
 
-      // replace linebreak with null
-      if(buffer_ptr[current_read-1] == '\n'){
-        buffer_ptr[current_read-1] = '\0';
-        total_read--;  // decrease the total reads count by one for the newline
-      }
+      // the last-read character on a successful readline should be '\n'
+      assert(buffer_ptr[current_read-1] == '\n');
+      buffer_ptr[current_read-1] = '\0'; // replace linebreak with null
+      total_read--;  // decrease the total reads count by one for the newline
       break;
     }
 

--- a/lib/formats/bs_format_ripejson.c
+++ b/lib/formats/bs_format_ripejson.c
@@ -260,7 +260,7 @@ static int readline(bgpstream_format_t *format)
     BUFSIZE += JSON_BUFFER_BLOCK_SIZE;
     STATE->json_string_buffer = (char*) realloc (STATE->json_string_buffer, BUFSIZE * sizeof(char));
     // point temporary buffer to the last read location
-    buffer_ptr = &STATE->json_string_buffer[total_read - 1];
+    buffer_ptr = &STATE->json_string_buffer[total_read];
     bgpstream_log(BGPSTREAM_LOG_INFO, "Json string buffer size increased to %d", BUFSIZE);
   }
 

--- a/lib/formats/bs_format_ripejson.c
+++ b/lib/formats/bs_format_ripejson.c
@@ -249,8 +249,10 @@ static int readline(bgpstream_format_t *format)
       // if read less than buffer, or last byte is an newline, readline is finished
 
       // replace linebreak with null
-      buffer_ptr[current_read-1] = '\0';
-      buffer_ptr += current_read - 1;
+      if(buffer_ptr[current_read-1] == '\n'){
+        buffer_ptr[current_read-1] = '\0';
+        total_read--;  // decrease the total reads count by one for the newline
+      }
       break;
     }
 
@@ -258,12 +260,13 @@ static int readline(bgpstream_format_t *format)
     // reallocate memory
     BUFSIZE += JSON_BUFFER_BLOCK_SIZE;
     STATE->json_string_buffer = (char*) realloc (STATE->json_string_buffer, BUFSIZE * sizeof(char));
+    // point temporary buffer to the last read location
     buffer_ptr = &STATE->json_string_buffer[total_read - 1];
     bgpstream_log(BGPSTREAM_LOG_INFO, "Json string buffer size increased to %d", BUFSIZE);
   }
 
   // calcualte how many bytes actually read
-  return buffer_ptr - STATE->json_string_buffer;
+  return total_read;
 }
 
 static bgpstream_format_status_t

--- a/lib/formats/bs_format_ripejson.c
+++ b/lib/formats/bs_format_ripejson.c
@@ -241,7 +241,7 @@ static int readline(bgpstream_format_t *format)
 
     if(current_read == 0){
       // reach EOF, no bytes read, return 0
-      return 0;
+      return total_read;
     }
 
     if(current_read < BUFSIZE - total_read -1 ||

--- a/lib/formats/bs_format_ripejson.c
+++ b/lib/formats/bs_format_ripejson.c
@@ -240,13 +240,13 @@ static int readline(bgpstream_format_t *format)
     total_read+=current_read;
 
     if(current_read == 0){
-      // reach EOF, no bytes read, return 0
+      // reaches EOF, no bytes read, return total_read
       return total_read;
     }
 
     if(current_read < BUFSIZE - total_read -1 ||
       buffer_ptr[current_read-1] == '\n'){
-      // if read less than buffer, or last byte is an newline, readline is finished
+      // if read less than a full buffer, or last byte is an newline, readline is finished
 
       // replace linebreak with null
       if(buffer_ptr[current_read-1] == '\n'){

--- a/lib/transports/bs_transport_cache.c
+++ b/lib/transports/bs_transport_cache.c
@@ -237,10 +237,10 @@ int bs_transport_cache_create(bgpstream_transport_t *transport)
 }
 
 int64_t bs_transport_cache_readline(bgpstream_transport_t *transport,
-                                    uint8_t *buffer, int64_t len)
+                                    uint8_t *buffer, int64_t len, int chomp)
 {
 
-  return wandio_generic_fgets(transport, buffer, len, 1,
+  return wandio_generic_fgets(transport, buffer, len, chomp,
                               (read_cb_t *)bs_transport_cache_read);
 }
 

--- a/lib/transports/bs_transport_file.c
+++ b/lib/transports/bs_transport_file.c
@@ -53,9 +53,9 @@ int64_t bs_transport_file_read(bgpstream_transport_t *transport,
 }
 
 int64_t bs_transport_file_readline(bgpstream_transport_t *transport,
-                                   uint8_t *buffer, int64_t len)
+                                   uint8_t *buffer, int64_t len, int chomp)
 {
-  return wandio_fgets((io_t *)transport->state, buffer, len, 1);
+  return wandio_fgets((io_t *)transport->state, buffer, len, chomp);
 }
 
 void bs_transport_file_destroy(bgpstream_transport_t *transport)

--- a/lib/transports/bs_transport_kafka.c
+++ b/lib/transports/bs_transport_kafka.c
@@ -294,7 +294,7 @@ static int handle_err_msg(bgpstream_transport_t *transport,
 }
 
 int64_t bs_transport_kafka_readline(bgpstream_transport_t *transport,
-                                    uint8_t *buffer, int64_t len)
+                                    uint8_t *buffer, int64_t len, int chomp)
 {
   int rc = bs_transport_kafka_read(transport, buffer, len - 1);
 


### PR DESCRIPTION
Issue details in #80.

- [X] change `transport_readline` function signature to allow retain newline during read
- [x] check newline when reading and expand buffer if no newline found