### PR TITLE
Don't fail on unknown AS path segment type

### DIFF
--- a/lib/utils/bgpstream_utils_as_path.c
+++ b/lib/utils/bgpstream_utils_as_path.c
@@ -99,7 +99,7 @@ seg_set_dup(bgpstream_as_path_seg_set_t *src)
 
 #define SET_SNPRINTF(fchr, lchr, schr)                                         \
   do {                                                                         \
-    char *bufp = buf;                                                          \
+    char *bufp = buf + written;                                                \
     bgpstream_as_path_seg_set_t *segset = (bgpstream_as_path_seg_set_t *)seg;  \
     ADD_CHAR(fchr);                                                            \
     int i;                                                                     \
@@ -157,9 +157,9 @@ int bgpstream_as_path_seg_snprintf(char *buf, size_t len,
     break;
 
   default:
-    written = 0;
-    if (len > 0)
-      *buf = '\0';
+    written =
+      snprintf(buf, len, "<Unknown segment type %d:", seg->type);
+      SET_SNPRINTF(' ', '>', ' ');
     break;
   }
 
@@ -570,19 +570,7 @@ int bgpstream_as_path_append(bgpstream_as_path_t *path,
   // get a pointer to the newly added segment
   seg = CUR_SEG(path, &iter);
 
-  switch (type) {
-  case BGPSTREAM_AS_PATH_SEG_SET:
-  case BGPSTREAM_AS_PATH_SEG_ASN:
-  case BGPSTREAM_AS_PATH_SEG_CONFED_SEQ:
-  case BGPSTREAM_AS_PATH_SEG_CONFED_SET:
-    seg->type = type;
-    break;
-
-  default:
-    bgpstream_log(BGPSTREAM_LOG_ERR, "AS_PATH with unknown segment type %d",
-                  type);
-    return -1;
-  }
+  seg->type = type;
 
   // TODO: this code will allow adjacent segments of the same type to be added
   // which is technically illegal.

--- a/lib/utils/bgpstream_utils_as_path.c
+++ b/lib/utils/bgpstream_utils_as_path.c
@@ -157,9 +157,8 @@ int bgpstream_as_path_seg_snprintf(char *buf, size_t len,
     break;
 
   default:
-    written =
-      snprintf(buf, len, "<Unknown segment type %d:", seg->type);
-      SET_SNPRINTF(' ', '>', ' ');
+    /* <A B C> */
+    SET_SNPRINTF('<', '>', ' ');
     break;
   }
 

--- a/lib/utils/bgpstream_utils_as_path.h
+++ b/lib/utils/bgpstream_utils_as_path.h
@@ -179,6 +179,9 @@ typedef struct bgpstream_as_path_iter {
  *   (BGPSTREAM_AS_PATH_SEG_CONFED_SEQ), then the string will be a
  *   space-separated list of ASNs, enclosed in parentheses.
  *   E.g., "(12345 6789)".
+ * - If the segment is an unknown type (this should not happen), then the
+ *   string will be a space-separated list of ASNs, enclosed in angle
+ *   brackets.  E.g., "<12345 6789>".
  * Note that it is possible to have a set/sequence with only a single element.
  */
 int bgpstream_as_path_seg_snprintf(char *buf, size_t len,


### PR DESCRIPTION
There's no need to abort the entire stream because of an unknown segment
type in an otherwise valid AS path segment.
bgpstream_as_path_seg_snprintf() now prints such a segment as e.g.
"<Unknown segment type 0: 13127>"