### PR TITLE
Suppress bogus warning from old clang -Wall

### DIFF
--- a/lib/bgpstream_transport.c
+++ b/lib/bgpstream_transport.c
@@ -70,7 +70,9 @@ bgpstream_transport_t *bgpstream_transport_create(bgpstream_resource_t *res)
   bgpstream_transport_t *transport = NULL;
 
   // check that the transport type is valid
-  if (res->transport_type >= ARR_CNT(create_functions)) {
+  // Note: the (int) cast is here to suppress a bogus warning from
+  // -Wtautological-constant-out-of-range-compare in some versions of clang
+  if ((int)res->transport_type >= ARR_CNT(create_functions)) {
     bgpstream_log(BGPSTREAM_LOG_ERR, "Invalid transport module for %s (ID: %d)",
                   res->uri, res->transport_type);
     goto err;


### PR DESCRIPTION
The warning was breaking the jenkins build.