### PR TITLE
unify information of resource returned from the broker

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -248,6 +248,7 @@ AC_MSG_NOTICE([configuring data interface parameters...])
 # broker options
 if test "x$with_di_broker" == xyes; then
    BS_DI_OPT(broker-url, BROKER_URL, Broker URL, https://broker.bgpstream.caida.org/test)
+   # BS_DI_OPT(broker-url, BROKER_URL, Broker URL, http://127.0.0.1:8000/v1)
 
    AC_MSG_CHECKING([whether to enable broker debugging output])
    AC_ARG_ENABLE([broker-debug],

--- a/lib/bgpstream_record.h
+++ b/lib/bgpstream_record.h
@@ -78,16 +78,16 @@ typedef enum {
 /** The type of livestream */
 typedef enum {
 
-  /** The record contains data for a BGP Update message */
-  BGPSTREAM_LIVE_RISLIVE = 0,
+  BGPSTREAM_RES_BATCH = 0,
 
-  /** The record contains data for a BGP RIB message */
-  BGPSTREAM_LIVE_BMP = 1,
+  BGPSTREAM_RES_RISLIVE = 1,
+
+  BGPSTREAM_RES_BMP = 2,
 
   /** INTERNAL: The number of record types in use */
-  _BGPSTREAM_LIVESTREAM_TYPE_CNT = 2,
+  _BGPSTREAM_RESOURCE_TYPE_CNT = 3,
 
-} bgpstream_livestream_type_t;
+} bgpstream_resource_type_t;
 
 /** The position of this record in the dump */
 typedef enum {

--- a/lib/datainterfaces/bsdi_broker.c
+++ b/lib/datainterfaces/bsdi_broker.c
@@ -199,7 +199,7 @@ static int process_json(bsdi_t *di, const char *js, jsmntok_t *root_tok,
   int project_set = 0;
   bgpstream_record_type_t type = 0;
   int type_set = 0;
-  bgpstream_livestream_type_t livestream_type = 0;
+  bgpstream_resource_type_t resource_type = 0;
   int livestream_type_set = 0;
   unsigned long initial_time = 0;
   int initial_time_set = 0;
@@ -264,243 +264,184 @@ static int process_json(bsdi_t *di, const char *js, jsmntok_t *root_tok,
       data_type_len = t->size;
       NEXT_TOK;
       for (l = 0; l < data_type_len; l++) {
-
-        if(jsmn_streq(js, t, "dumpFiles") == 1){
-          bgpstream_log(BGPSTREAM_LOG_INFO, "Processing DumpFiles");
-          jsmn_str_assert(js, t, "dumpFiles");
+        bgpstream_log(BGPSTREAM_LOG_INFO, "Processing resources");
+        jsmn_str_assert(js, t, "resources");
+        NEXT_TOK;
+        jsmn_type_assert(t, JSMN_ARRAY);
+        arr_len = t->size; // number of dump files
+        NEXT_TOK;          // first elem in array
+        for (j = 0; j < arr_len; j++) {
+          jsmn_type_assert(t, JSMN_OBJECT);
+          obj_len = t->size;
           NEXT_TOK;
-          jsmn_type_assert(t, JSMN_ARRAY);
-          arr_len = t->size; // number of dump files
-          NEXT_TOK;          // first elem in array
-          for (j = 0; j < arr_len; j++) {
-            jsmn_type_assert(t, JSMN_OBJECT);
-            obj_len = t->size;
-            NEXT_TOK;
 
-            url_set = 0;
-            project_set = 0;
-            collector_set = 0;
-            type_set = 0;
-            initial_time_set = 0;
-            duration_set = 0;
+          url_set = 0;
+          project_set = 0;
+          collector_set = 0;
+          type_set = 0;
+          initial_time_set = 0;
+          duration_set = 0;
 
-            for (k = 0; k < obj_len; k++) {
-              if (jsmn_streq(js, t, "urlType") == 1) {
-                NEXT_TOK;
-                if (jsmn_streq(js, t, "simple") != 1) {
-                  // not yet supported?
-                  bgpstream_log(BGPSTREAM_LOG_ERR, "Unsupported URL type '%.*s'",
-                                t->end - t->start, js + t->start);
-                  goto err;
-                }
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "url") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_STRING);
-                if (url_len < (t->end - t->start + 1)) {
-                  url_len = t->end - t->start + 1;
-                  if ((url = realloc(url, url_len)) == NULL) {
-                    bgpstream_log(BGPSTREAM_LOG_ERR,
-                                  "Could not realloc URL string");
-                    goto err;
-                  }
-                }
-                jsmn_strcpy(url, t, js);
-                unescape_url(url);
-                url_set = 1;
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "project") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_STRING);
-                jsmn_strcpy(project, t, js);
-                project_set = 1;
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "collector") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_STRING);
-                jsmn_strcpy(collector, t, js);
-                collector_set = 1;
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "type") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_STRING);
-                if (jsmn_streq(js, t, "ribs") == 1) {
-                  type = BGPSTREAM_RIB;
-                } else if (jsmn_streq(js, t, "updates") == 1) {
-                  type = BGPSTREAM_UPDATE;
-                } else {
-                  bgpstream_log(BGPSTREAM_LOG_ERR, "Invalid type '%.*s'",
-                                t->end - t->start, js + t->start);
-                  goto err;
-                }
-                type_set = 1;
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "initialTime") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_PRIMITIVE);
-                jsmn_strtoul(&initial_time, js, t);
-                initial_time_set = 1;
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "duration") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_PRIMITIVE);
-                jsmn_strtoul(&duration, js, t);
-                duration_set = 1;
-                NEXT_TOK;
+          for (k = 0; k < obj_len; k++) {
+            if (jsmn_streq(js, t, "urlType") == 1) {
+              NEXT_TOK;
+
+              if (jsmn_streq(js, t, "batch") == 1) {
+                resource_type = BGPSTREAM_RES_BATCH;
+              } else if (jsmn_streq(js, t, "ris-live") == 1) {
+                resource_type = BGPSTREAM_RES_RISLIVE;
+              } else if (jsmn_streq(js, t, "bmp") == 1) {
+                resource_type = BGPSTREAM_RES_BMP;
               } else {
-                bgpstream_log(BGPSTREAM_LOG_ERR, "Unknown field '%.*s'",
+                bgpstream_log(BGPSTREAM_LOG_ERR, "Unsupported URL type '%.*s'",
                               t->end - t->start, js + t->start);
                 goto err;
               }
-            }
-            // file obj has been completely read
-            if (url_set == 0 || project_set == 0 || collector_set == 0 ||
-                type_set == 0 || initial_time_set == 0 || duration_set == 0) {
-              bgpstream_log(BGPSTREAM_LOG_ERR, "Invalid dumpFile record");
-              goto retry;
-            }
-#ifdef BROKER_DEBUG
-            bgpstream_log(BGPSTREAM_LOG_INFO, "----------");
-            bgpstream_log(BGPSTREAM_LOG_INFO, "URL: %s", url);
-            bgpstream_log(BGPSTREAM_LOG_INFO, "Project: %s", project);
-            bgpstream_log(BGPSTREAM_LOG_INFO, "Collector: %s", collector);
-            bgpstream_log(BGPSTREAM_LOG_INFO, "Type: %d", type);
-            bgpstream_log(BGPSTREAM_LOG_INFO, "InitialTime: %lu", initial_time);
-            bgpstream_log(BGPSTREAM_LOG_INFO, "Duration: %lu", duration);
-#endif
-
-            // do we need to update our current_window_end?
-            if (initial_time + duration > STATE->current_window_end) {
-              STATE->current_window_end = (initial_time + duration);
-            }
-
-            transport_type = STATE->cache_dir == NULL
-              ? BGPSTREAM_RESOURCE_TRANSPORT_FILE
-              : BGPSTREAM_RESOURCE_TRANSPORT_CACHE;
-            if (bgpstream_resource_mgr_push(BSDI_GET_RES_MGR(di), transport_type,
-                                            BGPSTREAM_RESOURCE_FORMAT_MRT, url,
-                                            initial_time, duration, project,
-                                            collector, type, &res) < 0) {
-
+              NEXT_TOK;
+            } else if (jsmn_streq(js, t, "url") == 1) {
+              NEXT_TOK;
+              jsmn_type_assert(t, JSMN_STRING);
+              if (url_len < (t->end - t->start + 1)) {
+                url_len = t->end - t->start + 1;
+                if ((url = realloc(url, url_len)) == NULL) {
+                  bgpstream_log(BGPSTREAM_LOG_ERR,
+                                "Could not realloc URL string");
+                  goto err;
+                }
+              }
+              jsmn_strcpy(url, t, js);
+              unescape_url(url);
+              url_set = 1;
+              NEXT_TOK;
+            } else if (jsmn_streq(js, t, "project") == 1) {
+              NEXT_TOK;
+              jsmn_type_assert(t, JSMN_STRING);
+              jsmn_strcpy(project, t, js);
+              project_set = 1;
+              NEXT_TOK;
+            } else if (jsmn_streq(js, t, "collector") == 1) {
+              NEXT_TOK;
+              jsmn_type_assert(t, JSMN_STRING);
+              jsmn_strcpy(collector, t, js);
+              collector_set = 1;
+              NEXT_TOK;
+            } else if (jsmn_streq(js, t, "type") == 1) {
+              NEXT_TOK;
+              jsmn_type_assert(t, JSMN_STRING);
+              if (jsmn_streq(js, t, "ribs") == 1) {
+                type = BGPSTREAM_RIB;
+              } else if (jsmn_streq(js, t, "updates") == 1) {
+                type = BGPSTREAM_UPDATE;
+              } else {
+                bgpstream_log(BGPSTREAM_LOG_ERR, "Invalid type '%.*s'",
+                              t->end - t->start, js + t->start);
+                goto err;
+              }
+              type_set = 1;
+              NEXT_TOK;
+            } else if (jsmn_streq(js, t, "initialTime") == 1) {
+              NEXT_TOK;
+              jsmn_type_assert(t, JSMN_PRIMITIVE);
+              jsmn_strtoul(&initial_time, js, t);
+              initial_time_set = 1;
+              NEXT_TOK;
+            } else if (jsmn_streq(js, t, "duration") == 1) {
+              NEXT_TOK;
+              jsmn_type_assert(t, JSMN_PRIMITIVE);
+              jsmn_strtoul(&duration, js, t);
+              duration_set = 1;
+              NEXT_TOK;
+            } else {
+              bgpstream_log(BGPSTREAM_LOG_ERR, "Unknown field '%.*s'",
+                            t->end - t->start, js + t->start);
               goto err;
             }
-            // set cache attribute to resource
-            if (transport_type == BGPSTREAM_RESOURCE_TRANSPORT_CACHE &&
-                bgpstream_resource_set_attr(res,
-                                            BGPSTREAM_RESOURCE_ATTR_CACHE_DIR_PATH,
-                                            STATE->cache_dir) != 0) {
-              return -1;
-            }
           }
-          bgpstream_log(BGPSTREAM_LOG_INFO, "Finish processing DumpFiles");
-        }
-        else if(jsmn_streq(js, t, "liveStreams") == 1) {
-          bgpstream_log(BGPSTREAM_LOG_INFO, "Processing LIVESTREAMS");
-          NEXT_TOK;
-          jsmn_type_assert(t, JSMN_ARRAY);
-          arr_len = t->size; // number of dump files
-          NEXT_TOK;          // first elem in array
-          for (j = 0; j < arr_len; j++) {
-            jsmn_type_assert(t, JSMN_OBJECT);
-            obj_len = t->size;
-            NEXT_TOK;
-            for (k = 0; k < obj_len; k++) {
-              if (jsmn_streq(js, t, "streamType") == 1) {
-                NEXT_TOK;
-                if (jsmn_streq(js, t, "rislive") == 1) {
-                  livestream_type = BGPSTREAM_LIVE_RISLIVE;
-                } else if (jsmn_streq(js, t, "bmp") == 1) {
-                  livestream_type = BGPSTREAM_LIVE_BMP;
-                } else {
-                  bgpstream_log(BGPSTREAM_LOG_ERR, "Invalid type '%.*s'",
-                                t->end - t->start, js + t->start);
-                  goto err;
-                }
-                livestream_type_set = 1;
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "url") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_STRING);
-                if (url_len < (t->end - t->start + 1)) {
-                  url_len = t->end - t->start + 1;
-                  if ((url = realloc(url, url_len)) == NULL) {
-                    bgpstream_log(BGPSTREAM_LOG_ERR,
-                                  "Could not realloc URL string");
-                    goto err;
-                  }
-                }
-                jsmn_strcpy(url, t, js);
-                unescape_url(url);
-                url_set = 1;
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "project") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_STRING);
-                jsmn_strcpy(project, t, js);
-                project_set = 1;
-                NEXT_TOK;
-              } else if (jsmn_streq(js, t, "collector") == 1) {
-                NEXT_TOK;
-                jsmn_type_assert(t, JSMN_STRING);
-                jsmn_strcpy(collector, t, js);
-                collector_set = 1;
-                NEXT_TOK;
-              }
-            }
-            // file obj has been completely read
-            // validate stream resource here
-            if (url_set == 0 || project_set == 0 || collector_set == 0 || livestream_type_set == 0) {
-              bgpstream_log(BGPSTREAM_LOG_ERR, "Invalid liveStream record");
-              goto retry;
-            }
 
 #ifdef BROKER_DEBUG
-            bgpstream_log(BGPSTREAM_LOG_INFO, "----------");
-            bgpstream_log(BGPSTREAM_LOG_INFO, "Live stream URL: %s", url);
-            bgpstream_log(BGPSTREAM_LOG_INFO, "Live stream Project: %s", project);
-            bgpstream_log(BGPSTREAM_LOG_INFO, "Live stream Collector: %s", collector);
-            bgpstream_log(BGPSTREAM_LOG_INFO, "Live stream Type: %d", livestream_type);
+          bgpstream_log(BGPSTREAM_LOG_INFO, "----------");
+          bgpstream_log(BGPSTREAM_LOG_INFO, "Resource Type: %d", resource_type);
+          bgpstream_log(BGPSTREAM_LOG_INFO, "URL: %s", url);
+          bgpstream_log(BGPSTREAM_LOG_INFO, "Project: %s", project);
+          bgpstream_log(BGPSTREAM_LOG_INFO, "Collector: %s", collector);
+          bgpstream_log(BGPSTREAM_LOG_INFO, "Type: %d", type);
+          bgpstream_log(BGPSTREAM_LOG_INFO, "InitialTime: %lu", initial_time);
+          bgpstream_log(BGPSTREAM_LOG_INFO, "Duration: %lu", duration);
 #endif
-            switch(livestream_type){
-              case BGPSTREAM_LIVE_RISLIVE:
-                if (bgpstream_resource_mgr_push(
-                      BSDI_GET_RES_MGR(di), BGPSTREAM_RESOURCE_TRANSPORT_HTTP,
-                      BGPSTREAM_RESOURCE_FORMAT_RIPEJSON, url,
-                      0,                   // indicate we don't know how much historical data there is
-                      BGPSTREAM_FOREVER,   // indicate that the resource is a "stream"
-                      "ris-live",          // fix project name to "ris-live"
-                      "",                  // leave collector unset
-                      BGPSTREAM_UPDATE,
-                      &res) <= 0) {
-                  goto err;
-                }
-                break;
-              case BGPSTREAM_LIVE_BMP:
-                // TODO: handle brokers
-                // if (bgpstream_resource_mgr_push(
-                //        BSDI_GET_RES_MGR(di), BGPSTREAM_RESOURCE_TRANSPORT_KAFKA,
-                //        BGPSTREAM_RESOURCE_FORMAT_BMP, STATE->brokers,
-                //        0, // indicate we don't know how much historical data there is
-                //        BGPSTREAM_FOREVER, // indicate that the resource is a "stream"
-                //        project,   // fix our project to "caida"
-                //        "", // leave collector unset since we'll get it from openbmp hdrs
-                //        BGPSTREAM_UPDATE, //
-                //        &res) <= 0) {
-                //   goto err;
-                // }
-                break;
-              default:
-                break;
-            }
+          switch(resource_type){
+            case BGPSTREAM_RES_BATCH:
+              // file obj has been completely read
+              if (url_set == 0 || project_set == 0 || collector_set == 0 ||
+                  type_set == 0 || initial_time_set == 0 || duration_set == 0) {
+                bgpstream_log(BGPSTREAM_LOG_ERR, "Invalid dumpFile record");
+                goto retry;
+              }
+
+              // do we need to update our current_window_end?
+              if (initial_time + duration > STATE->current_window_end) {
+                STATE->current_window_end = (initial_time + duration);
+              }
+
+              transport_type = STATE->cache_dir == NULL
+                ? BGPSTREAM_RESOURCE_TRANSPORT_FILE
+                : BGPSTREAM_RESOURCE_TRANSPORT_CACHE;
+              if (bgpstream_resource_mgr_push(BSDI_GET_RES_MGR(di), transport_type,
+                                              BGPSTREAM_RESOURCE_FORMAT_MRT, url,
+                                              initial_time, duration, project,
+                                              collector, type, &res) < 0) {
+
+                goto err;
+              }
+              // set cache attribute to resource
+              if (transport_type == BGPSTREAM_RESOURCE_TRANSPORT_CACHE &&
+                  bgpstream_resource_set_attr(res,
+                                              BGPSTREAM_RESOURCE_ATTR_CACHE_DIR_PATH,
+                                              STATE->cache_dir) != 0) {
+                return -1;
+              }
+              break;
+
+            case BGPSTREAM_RES_RISLIVE:
+              // validate stream resource here
+              if (url_set == 0 || project_set == 0 || collector_set == 0) {
+                bgpstream_log(BGPSTREAM_LOG_ERR, "Invalid liveStream record");
+                goto retry;
+              }
+              if (bgpstream_resource_mgr_push(
+                    BSDI_GET_RES_MGR(di), BGPSTREAM_RESOURCE_TRANSPORT_HTTP,
+                    BGPSTREAM_RESOURCE_FORMAT_RIPEJSON, url,
+                    0,                   // indicate we don't know how much historical data there is
+                    BGPSTREAM_FOREVER,   // indicate that the resource is a "stream"
+                    project,
+                    "",                  // leave collector unset
+                    BGPSTREAM_UPDATE,
+                    &res) <= 0) {
+                goto err;
+              }
+              break;
+
+            case BGPSTREAM_RES_BMP:
+              if (bgpstream_resource_mgr_push(
+                    BSDI_GET_RES_MGR(di), BGPSTREAM_RESOURCE_TRANSPORT_KAFKA,
+                    BGPSTREAM_RESOURCE_FORMAT_BMP, url,
+                    0, // indicate we don't know how much historical data there is
+                    BGPSTREAM_FOREVER, // indicate that the resource is a "stream"
+                    project,
+                    "", // leave collector unset since we'll get it from openbmp hdrs
+                    BGPSTREAM_UPDATE, //
+                    &res) <= 0) {
+                goto err;
+              }
+              break;
+            default:
+              break;
           }
-        } else {
-          bgpstream_log(BGPSTREAM_LOG_ERR, "WRONG DATA TYPE");
         }
+        bgpstream_log(BGPSTREAM_LOG_INFO, "Finish processing resources");
       }
     }
-    // TODO: handle unknown tokens
   }
-
+  // TODO: handle unknown tokens
   if (time_set == 0) {
     goto err;
   }


### PR DESCRIPTION
instead of returning `dumpFiles` and `liveStreams`, broker now returns unified `resource` that can be directly parsed and put into resource manager now.