### PR TITLE
Add resource-type filter type

### DIFF
--- a/lib/bgpstream.h.in
+++ b/lib/bgpstream.h.in
@@ -128,6 +128,9 @@ typedef enum {
   /** Filter elems based on the element type, e.g. withdrawals, announcements */
   BGPSTREAM_FILTER_TYPE_ELEM_TYPE,
 
+  /** Filter records based on resource type (i.e., 'stream', or 'batch') */
+  BGPSTREAM_FILTER_TYPE_RESOURCE_TYPE,
+
 } bgpstream_filter_type_t;
 
 /** Data Interface IDs */

--- a/lib/bgpstream_filter.c
+++ b/lib/bgpstream_filter.c
@@ -311,6 +311,16 @@ int bgpstream_filter_mgr_filter_add(bgpstream_filter_mgr_t *this,
     }
     return bsf_str_set_insert(&this->bgp_types, filter_value);
 
+  case BGPSTREAM_FILTER_TYPE_RESOURCE_TYPE:
+    if (strcmp(filter_value, "stream") != 0 &&
+        strcmp(filter_value, "batch") != 0) {
+      bgpstream_log(
+        BGPSTREAM_LOG_ERR,
+        "resource-type filter must be one of \"stream\" or \"batch\"");
+      return 0;
+    }
+    return bsf_str_set_insert(&this->res_types, filter_value);
+
   default:
     bgpstream_log(BGPSTREAM_LOG_ERR, "unknown filter %d", filter_type);
     return 0;
@@ -397,6 +407,10 @@ void bgpstream_filter_mgr_destroy(bgpstream_filter_mgr_t *this)
   // bgp_types
   if (this->bgp_types != NULL) {
     bgpstream_str_set_destroy(this->bgp_types);
+  }
+  // res_types
+  if (this->res_types != NULL) {
+    bgpstream_str_set_destroy(this->res_types);
   }
   // peer asns
   if (this->peer_asns != NULL) {

--- a/lib/bgpstream_filter.h
+++ b/lib/bgpstream_filter.h
@@ -68,6 +68,7 @@ typedef struct struct_bgpstream_filter_mgr_t {
   bgpstream_str_set_t *collectors;
   bgpstream_str_set_t *routers;
   bgpstream_str_set_t *bgp_types;
+  bgpstream_str_set_t *res_types;
   bgpstream_aspath_expr_t *aspath_exprs;
   int aspath_expr_cnt;
   int aspath_expr_alloc_cnt;

--- a/lib/bgpstream_filter_parser.c
+++ b/lib/bgpstream_filter_parser.c
@@ -70,6 +70,8 @@ static const char *bgpstream_filter_type_to_string(bgpstream_filter_type_t type)
     return "Prefix (old format)";
   case BGPSTREAM_FILTER_TYPE_ELEM_TYPE:
     return "Element Type";
+  case BGPSTREAM_FILTER_TYPE_RESOURCE_TYPE:
+    return "Resource Type";
   }
 
   return "Unknown filter term ??";
@@ -94,6 +96,7 @@ static int instantiate_filter(bgpstream_t *bs, bgpstream_filter_item_t *item)
   case BGPSTREAM_FILTER_TYPE_ELEM_ASPATH:
   case BGPSTREAM_FILTER_TYPE_ELEM_IP_VERSION:
   case BGPSTREAM_FILTER_TYPE_ELEM_TYPE:
+  case BGPSTREAM_FILTER_TYPE_RESOURCE_TYPE:
     bgpstream_log(BGPSTREAM_LOG_FINE, "Adding filter: %s '%s'",
         bgpstream_filter_type_to_string(item->termtype), item->value);
     if (!bgpstream_add_filter(bs, usetype, item->value))
@@ -119,6 +122,7 @@ static int instantiate_filter(bgpstream_t *bs, bgpstream_filter_item_t *item)
   X(1,  "collector",    "coll", COLLECTOR,               VALUE) \
   X(1,  "router",       "rout", ROUTER,                  VALUE) \
   X(1,  "type",         NULL,   RECORD_TYPE,             VALUE) \
+  X(1,  "resourcetype", "restype", RESOURCE_TYPE,        VALUE)  \
   X(1,  "peer",         NULL,   ELEM_PEER_ASN,           VALUE) \
   X(1,  "origin",       "orig", ELEM_ORIGIN_ASN,         VALUE)     \
   X(1,  "prefix",       "pref", ELEM_PREFIX_MORE,        PREFIXEXT) \

--- a/lib/datainterfaces/bsdi_broker.c
+++ b/lib/datainterfaces/bsdi_broker.c
@@ -651,8 +651,8 @@ static int update_query_url(bsdi_t *di)
   // http://bgpstream.caida.org/broker/data?
   APPEND_STR("/data");
 
-  // projects, collectors, bgp_types, and time_interval are used as filters
-  // only if they are provided by the user
+  // projects, collectors, bgp_types, res_types, and time_interval are
+  // used as filters only if they are provided by the user
 
   // projects
   char *f;
@@ -702,6 +702,15 @@ static int update_query_url(bsdi_t *di)
     while ((f = bgpstream_str_set_next(filter_mgr->bgp_types)) != NULL) {
       AMPORQ;
       APPEND_STR("types[]=");
+      APPEND_STR(f);
+    }
+  }
+  // res_types
+  if (filter_mgr->res_types != NULL) {
+    bgpstream_str_set_rewind(filter_mgr->res_types);
+    while ((f = bgpstream_str_set_next(filter_mgr->res_types)) != NULL) {
+      AMPORQ;
+      APPEND_STR("resourceTypes[]=");
       APPEND_STR(f);
     }
   }

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -114,6 +114,9 @@ static struct bs_options_t bs_opts[] =
   {{"record-type", required_argument, 0, 't'},
    "<type>",
    "process records with only the given type (ribs, updates)*"},
+  {{"resource-type", required_argument, 0, 'T'},
+   "<resource-type>",
+   "process records from only the given resource type (stream, batch)*"},
   {{"time-window", required_argument, 0, 'w'},
    "<start>[,<end>]",
    "process records within the given time window.  <start> and <end> may be in "
@@ -429,6 +432,8 @@ int main(int argc, char *argv[])
     PARSE_FILTER_OPTION('A', BGPSTREAM_FILTER_TYPE_ELEM_ASPATH)
       break;
     PARSE_FILTER_OPTION('t', BGPSTREAM_FILTER_TYPE_RECORD_TYPE)
+      break;
+    PARSE_FILTER_OPTION('T', BGPSTREAM_FILTER_TYPE_RESOURCE_TYPE)
       break;
 
     case 'o':


### PR DESCRIPTION
This allows a user to tell the broker whether they want stream resources (e.g., ris live, bmp), batch resources (the MRT files), or both.