### PR TITLE
Improve handling of ris-live HTTP errors

### DIFF
--- a/lib/bgpstream_reader.c
+++ b/lib/bgpstream_reader.c
@@ -93,6 +93,11 @@ static int prefetch_record(bgpstream_reader_t *reader)
   // try and get the next entry from the resource (will do filtering)
   reader->status = bgpstream_format_populate_record(reader->format, record);
 
+  // exit with error in case of read error
+  if (reader->status == BGPSTREAM_FORMAT_READ_ERROR) {
+    return -1;
+  }
+
   // if we got any of the non-error END_OF_DUMP messages but this is a stream
   // resource, then pretend we're ok.  but beware that now we'll be "OK", with
   // an unfilled prefetch record

--- a/lib/bgpstream_resource_mgr.c
+++ b/lib/bgpstream_resource_mgr.c
@@ -53,9 +53,9 @@ struct res_list_elem {
   /** Is the reader open? (i.e. have we waited for it to open) */
   int open;
 
-  /** Time when this resource should next be polled (if 0 then poll
+  /** Time in ms when this resource should next be polled (if 0 then poll
       immediately) */
-  uint32_t next_poll;
+  uint64_t next_poll;
 
   /** Previous list elem */
   struct res_list_elem *prev;
@@ -651,7 +651,7 @@ static bgpstream_reader_status_t pop_record(bgpstream_resource_mgr_t *q,
   bgpstream_reader_status_t rs;
   struct res_list_elem *el = NULL;
   struct res_group *gp = NULL;
-  uint32_t now;
+  uint64_t now;
   uint64_t sleep_nsec;
   struct timespec rqtp;
 

--- a/lib/formats/bs_format_rislive.c
+++ b/lib/formats/bs_format_rislive.c
@@ -584,7 +584,7 @@ retry:
     return BGPSTREAM_FORMAT_CORRUPTED_DUMP;
   } else if (STATE->json_string_buffer_len == 0) {
     // end of dump
-    return BGPSTREAM_FORMAT_END_OF_DUMP;
+    return BGPSTREAM_FORMAT_READ_ERROR;
   }
 
   if ((rc = bs_format_process_json_fields(format, record)) != 0) {


### PR DESCRIPTION
Hi,

While debugging ris-live errors (`HTTP ERROR: Transferred a partial file (18)`) I found a few small issues in the code, fixed/improved in the below 2 commits.

 * fc712723397141a4e426d854927de42593534648 fixes an integer overflow error, where a timestamp in milliseconds was written to an uint32_t, which somehow didn't manifest for me
 * 44fb56eb3bfc7d0d0c2afa0849a3674a88289f7d is a poor-man's solution to no HTTP read error handling in ris-live (I was really surprised to see this guys... :P) see also #139 

Thanks for your great work!