### PR TITLE
use quilt format for debian build

### DIFF
--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
This allows us to build `deb` packages in debian for unstable and versions with revisions.