### PR TITLE
Bump version to rc1-2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libbgpstream2 (2.0.0~rc1-2) unstable; urgency=medium
+
+  * Fix librdkafka-dev dependency for debian packages
+
+ -- Alistair King <software@caida.org>  Wed, 23 Oct 2019 18:47:01 +0000
+ 
 libbgpstream2 (2.0.0~rc1-1) unstable; urgency=medium
 
   * Various fixes and improvements to debian packaging


### PR DESCRIPTION
Force release a newer version of the libbgpstream packages for the fix of librdkafka-dev dependency fix.