### PR TITLE
add checking for bgpstream broker version

### DIFF
--- a/lib/datainterfaces/bsdi_broker.c
+++ b/lib/datainterfaces/bsdi_broker.c
@@ -123,6 +123,8 @@ BSDI_CREATE_CLASS(
    this) */
 #define URL_BUFLEN 4096
 
+#define BROKER_VERSION 2
+
 typedef struct bsdi_broker_state {
 
   /* user-provided options: */
@@ -269,9 +271,9 @@ static int process_json(bsdi_t *di, const char *js, jsmntok_t *root_tok,
     if (jsmn_streq(js, t, "version") == 1) {
       NEXT_TOK;
       jsmn_strtoul(&version, js, t);
-      if(version != BGPSTREAM_MAJOR_VERSION){
-        bgpstream_log(BGPSTREAM_LOG_ERR, "Broker version does not match: libbgpstream=%d broker=%.*s",
-                      BGPSTREAM_MAJOR_VERSION, t->end - t->start, js + t->start);
+      if(version != BROKER_VERSION){
+        bgpstream_log(BGPSTREAM_LOG_ERR, "Broker version does not match: wanted=%d received=%.*s",
+                      BROKER_VERSION, t->end - t->start, js + t->start);
         goto err;
       }
       NEXT_TOK;

--- a/lib/datainterfaces/bsdi_broker.c
+++ b/lib/datainterfaces/bsdi_broker.c
@@ -239,6 +239,7 @@ static int process_json(bsdi_t *di, const char *js, jsmntok_t *root_tok,
   unsigned long initial_time = 0;
   int initial_time_set = 0;
   unsigned long duration = 0;
+  unsigned long version = 0;
   int duration_set = 0;
   char *kafka_topic = NULL;
   size_t topic_len = 0;
@@ -265,7 +266,16 @@ static int process_json(bsdi_t *di, const char *js, jsmntok_t *root_tok,
                     t->end - t->start, js + t->start);
       goto err;
     }
-    if (jsmn_streq(js, t, "time") == 1) {
+    if (jsmn_streq(js, t, "version") == 1) {
+      NEXT_TOK;
+      jsmn_strtoul(&version, js, t);
+      if(version != BGPSTREAM_MAJOR_VERSION){
+        bgpstream_log(BGPSTREAM_LOG_ERR, "Broker version does not match: libbgpstream=%d broker=%.*s",
+                      BGPSTREAM_MAJOR_VERSION, t->end - t->start, js + t->start);
+        goto err;
+      }
+      NEXT_TOK;
+    } else if (jsmn_streq(js, t, "time") == 1) {
       NEXT_TOK;
       jsmn_type_assert(t, JSMN_PRIMITIVE);
       unsigned long tmp = 0;


### PR DESCRIPTION
Exit with error if the bgpstream major version does not match the broker response version. 
It only executes checking if the broker returns a version number, therefore it is safe against older version of the broker who does not return version number.