### PR TITLE
RIS-live stream error handling

### DIFF
--- a/test/bgpstream-test-rislive.c
+++ b/test/bgpstream-test-rislive.c
@@ -53,6 +53,7 @@ static const char *valid_output[] = {
   "",
   "",
   "",
+  "",
 };
 
 static char buf[65536];
@@ -154,7 +155,7 @@ static int test_bgpstream_rislive()
     rcount++;
   }
 
-  if (rcount != 7) {
+  if (rcount != 8) {
     // if not all 7 records passed
     return -1;
   }

--- a/test/ris-live-stream.json
+++ b/test/ris-live-stream.json
@@ -5,3 +5,4 @@
 {"type": "ris_message", "data": {"timestamp": 1553625081.88, "peer": "195.66.224.59", "peer_asn": "24931", "id": "195.66.224.59-1553625081.88-235807", "host": "rrc01", "type": "RIS_PEER_STATE", "state": "down"}}
 {"type": "ris_message", "data": {"timestamp": 1553625034.06, "peer": "80.249.210.89", "peer_asn": "31042", "id": "80.249.210.89-1553625034.06-3003976", "raw": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF001304", "host": "rrc03", "type": "CEEPALIVE"}}
 {"type": "ris_message", "data": {"timestamp": 1553625034.06, "peer": "80.249.210.89", "peer_asn": "31042", "id": "80.249.210.89-1553625034.06-3003976", "raw": "FF1FFFFFFFFFFFFFFFFFFFFFFFFFFFFF001304", "host": "rrc03", "type": "KEEPALIVE"}}
+{"type":"ris_error","data":{"message":"this is a test error message"}}


### PR DESCRIPTION
We current need to handle two types of errors related to RIS-live stream:
- [X] error messages directly from ris-live server (see #139)
- [X] initial connection error when first connect to the ris-live server
  - this issue is handled in wandio, see https://github.com/wanduow/wandio/pull/43