### PR TITLE
Only print kafka_topic debug message if transport is kafka

### DIFF
--- a/lib/datainterfaces/bsdi_broker.c
+++ b/lib/datainterfaces/bsdi_broker.c
@@ -456,9 +456,11 @@ static int process_json(bsdi_t *di, const char *js, jsmntok_t *root_tok,
           bgpstream_log(BGPSTREAM_LOG_INFO, "Type: %d", type);
           bgpstream_log(BGPSTREAM_LOG_INFO, "InitialTime: %lu", initial_time);
           bgpstream_log(BGPSTREAM_LOG_INFO, "Duration: %lu", duration);
-          if(kafka_topic != NULL){
+#ifdef WITH_KAFKA
+          if (transport_type == BGPSTREAM_RESOURCE_TRANSPORT_KAFKA && kafka_topic != NULL){
             bgpstream_log(BGPSTREAM_LOG_INFO, "Kafka topic: %s", kafka_topic);
           }
+#endif
 #endif
           if (url_set == 0 || project_set == 0 || collector_set == 0 ||
               type_set == 0 || initial_time_set == 0 || duration_set == 0 ||


### PR DESCRIPTION
Tested with success:

```
mingwei@hammer01:~/git/caida-git/libbgpstream$ ./tools/bgpreader -w'2020-04-16' -t updates -c rrc00
2020-04-29 13:45:22 52000: bsdi_broker.c:961: INFO: Query URL: "https://broker.bgpstream.caida.org/v2/data?collectors[]=rrc00&types[]=updates&intervals[]=1586995200,0"
2020-04-29 13:45:22 52000: bsdi_broker.c:450: INFO: ----------
2020-04-29 13:45:22 52000: bsdi_broker.c:451: INFO: Transport Type: 1
2020-04-29 13:45:22 52000: bsdi_broker.c:452: INFO: Format Type: 1
2020-04-29 13:45:22 52000: bsdi_broker.c:453: INFO: URL: bmp.bgpstream.caida.org
2020-04-29 13:45:22 52000: bsdi_broker.c:454: INFO: Project: caida-bmp
2020-04-29 13:45:22 52000: bsdi_broker.c:455: INFO: Collector:
2020-04-29 13:45:22 52000: bsdi_broker.c:456: INFO: Type: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:457: INFO: InitialTime: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:458: INFO: Duration: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:461: INFO: Kafka topic: ^openbmp\.router--.+\.peer-as--.+\.bmp_raw
2020-04-29 13:45:22 52000: bsdi_broker.c:450: INFO: ----------
2020-04-29 13:45:22 52000: bsdi_broker.c:451: INFO: Transport Type: 3
2020-04-29 13:45:22 52000: bsdi_broker.c:452: INFO: Format Type: 2
2020-04-29 13:45:22 52000: bsdi_broker.c:453: INFO: URL: https://ris-live.ripe.net/v1/stream/?format=json&client=bgpstream-broker
2020-04-29 13:45:22 52000: bsdi_broker.c:454: INFO: Project: ris-live
2020-04-29 13:45:22 52000: bsdi_broker.c:455: INFO: Collector:
2020-04-29 13:45:22 52000: bsdi_broker.c:456: INFO: Type: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:457: INFO: InitialTime: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:458: INFO: Duration: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:450: INFO: ----------
2020-04-29 13:45:22 52000: bsdi_broker.c:451: INFO: Transport Type: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:452: INFO: Format Type: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:453: INFO: URL: http://bgp-archive.caida.org/ris/rrc00/updates/2020/04/15/ris.rrc00.updates.1586994900.gz
2020-04-29 13:45:22 52000: bsdi_broker.c:454: INFO: Project: ris
2020-04-29 13:45:22 52000: bsdi_broker.c:455: INFO: Collector: rrc00
2020-04-29 13:45:22 52000: bsdi_broker.c:456: INFO: Type: 0
2020-04-29 13:45:22 52000: bsdi_broker.c:457: INFO: InitialTime: 1586994900
2020-04-29 13:45:22 52000: bsdi_broker.c:458: INFO: Duration: 300
2020-04-29 13:45:22 52000: bsdi_broker.c:450: INFO: ----------
```