### PR TITLE
bump changelog's version number to 2.0.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libbgpstream2 (2.0.0) unstable; urgency=medium
+
+  * libbgpstream version 2.0.0 release
+
+ -- Alistair King <software@caida.org>  Fri, 21 Aug 2020 08:00:00 -0800
+
 libbgpstream2 (2.0.0~rc5) unstable; urgency=medium
 
   * Fifth public release candidate for libbgpstream version 2.0.0


### PR DESCRIPTION
This is the only changes needed for bumping the release version to 2.0.0. `configure.ac` has been 2.0.0 since the beginning.