### PR TITLE
Add utility functions to iterate over a prefix set

### DIFF
--- a/lib/utils/bgpstream_utils_pfx_set.c
+++ b/lib/utils/bgpstream_utils_pfx_set.c
@@ -158,6 +158,16 @@ void bgpstream_pfx_set_clear(bgpstream_pfx_set_t *set)
   kh_clear(bgpstream_ipv6_pfx_set, set->v6hash);
 }
 
+int bgpstream_pfx_set_iterate(bgpstream_pfx_set_t *set,
+    void (*callback)(bgpstream_pfx_t *, void *), void *userdata)
+{
+  if (bgpstream_ipv4_pfx_set_iterate(set->v4hash, callback, userdata) < 0 ||
+      bgpstream_ipv6_pfx_set_iterate(set->v6hash, callback, userdata) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
 /* IPv4 */
 
 bgpstream_ipv4_pfx_set_t *bgpstream_ipv4_pfx_set_create()
@@ -233,6 +243,21 @@ void bgpstream_ipv4_pfx_set_destroy(bgpstream_ipv4_pfx_set_t *set)
 void bgpstream_ipv4_pfx_set_clear(bgpstream_ipv4_pfx_set_t *set)
 {
   kh_clear(bgpstream_ipv4_pfx_set, set->hash);
+}
+
+int bgpstream_ipv4_pfx_set_iterate(bgpstream_ipv4_pfx_set_t *set,
+        void (*callback)(bgpstream_pfx_t *, void *), void *userdata)
+{
+  khiter_t k;
+  bgpstream_pfx_t pfx;
+  for (k = kh_begin(set->hash); k != kh_end(set->hash); ++k) {
+    if (kh_exist(set->hash, k)) {
+      pfx.bs_ipv4 = kh_key(set->hash, k);
+      pfx.address.version = BGPSTREAM_ADDR_VERSION_IPV4;
+      callback(&pfx, userdata);
+    }
+  }
+  return 0;
 }
 
 /* IPv6 */
@@ -311,3 +336,20 @@ void bgpstream_ipv6_pfx_set_clear(bgpstream_ipv6_pfx_set_t *set)
 {
   kh_clear(bgpstream_ipv6_pfx_set, set->hash);
 }
+
+int bgpstream_ipv6_pfx_set_iterate(bgpstream_ipv6_pfx_set_t *set,
+        void (*callback)(bgpstream_pfx_t *, void *), void *userdata)
+{
+  khiter_t k;
+  bgpstream_pfx_t pfx;
+  for (k = kh_begin(set->hash); k != kh_end(set->hash); ++k) {
+    if (kh_exist(set->hash, k)) {
+      pfx.bs_ipv6 = kh_key(set->hash, k);
+      pfx.address.version = BGPSTREAM_ADDR_VERSION_IPV6;
+      callback(&pfx, userdata);
+    }
+  }
+  return 0;
+}
+
+

--- a/lib/utils/bgpstream_utils_pfx_set.h
+++ b/lib/utils/bgpstream_utils_pfx_set.h
@@ -131,6 +131,21 @@ void bgpstream_pfx_set_destroy(bgpstream_pfx_set_t *set);
  */
 void bgpstream_pfx_set_clear(bgpstream_pfx_set_t *set);
 
+/** Iterate over a prefix set and invoke a callback function against each
+ *  prefix in the set.
+ *
+ *  @param set          pointer to the prefix set to iterate over
+ *  @param callback     callback function to invoke on each prefix, takes
+ *                      two parameters (the prefix and a void * for passing
+ *                      in external data variables.
+ *  @param userdata     pointer to a structure containing external data
+ *                      variables that may be required by the callback function.
+ *
+ *  @return 0 if the iteration completes successfully, -1 otherwise.
+ */
+int bgpstream_pfx_set_iterate(bgpstream_pfx_set_t *set,
+    void (*callback)(bgpstream_pfx_t *, void *), void *userdata);
+
 /* IPv4 */
 
 /** Create a new IPv4 Prefix set instance
@@ -188,6 +203,21 @@ void bgpstream_ipv4_pfx_set_destroy(bgpstream_ipv4_pfx_set_t *set);
  */
 void bgpstream_ipv4_pfx_set_clear(bgpstream_ipv4_pfx_set_t *set);
 
+/** Iterate over an IPv4 prefix set and invoke a callback function against each
+ *  prefix in the set.
+ *
+ *  @param set          pointer to the prefix set to iterate over
+ *  @param callback     callback function to invoke on each prefix, takes
+ *                      two parameters (the prefix and a void * for passing
+ *                      in external data variables.
+ *  @param userdata     pointer to a structure containing external data
+ *                      variables that may be required by the callback function.
+ *
+ *  @return 0 if the iteration completes successfully, -1 otherwise.
+ */
+int bgpstream_ipv4_pfx_set_iterate(bgpstream_ipv4_pfx_set_t *set,
+    void (*callback)(bgpstream_pfx_t *, void *), void *userdata);
+
 /** Create a new IPv6 Prefix set instance
  *
  * @return a pointer to the structure, or NULL if an error occurred
@@ -242,5 +272,20 @@ void bgpstream_ipv6_pfx_set_destroy(bgpstream_ipv6_pfx_set_t *set);
  * @param set           pointer to the prefix set to clear
  */
 void bgpstream_ipv6_pfx_set_clear(bgpstream_ipv6_pfx_set_t *set);
+
+/** Iterate over an IPv6 prefix set and invoke a callback function against each
+ *  prefix in the set.
+ *
+ *  @param set          pointer to the prefix set to iterate over
+ *  @param callback     callback function to invoke on each prefix, takes
+ *                      two parameters (the prefix and a void * for passing
+ *                      in external data variables.
+ *  @param userdata     pointer to a structure containing external data
+ *                      variables that may be required by the callback function.
+ *
+ *  @return 0 if the iteration completes successfully, -1 otherwise.
+ */
+int bgpstream_ipv6_pfx_set_iterate(bgpstream_ipv6_pfx_set_t *set,
+    void (*callback)(bgpstream_pfx_t *, void *), void *userdata);
 
 #endif /* __BGPSTREAM_UTILS_PFX_SET_H */


### PR DESCRIPTION
A callback method must be passed in by the user that will be run against each prefix in the set.

I'm using this iteration method in bgpview to construct a patricia tree from a prefix set, so figured it would be useful to have as a general utility function in the libbgpstream utils code.