### PR TITLE
Implement RFC 8050/7911 MRT Additional Path extension

### DIFF
--- a/lib/bgpstream_bgpdump.c
+++ b/lib/bgpstream_bgpdump.c
@@ -70,12 +70,14 @@ char *bgpstream_record_elem_bgpdump_snprintf(char *buf, size_t len,
   /* Record type */
   switch (elem->type) {
   case BGPSTREAM_ELEM_TYPE_RIB:
-    c = snprintf(buf_p, B_REMAIN, "TABLE_DUMP2|%" PRIu32, record->time_sec);
+    c = snprintf(buf_p, B_REMAIN, "TABLE_DUMP2%s|%" PRIu32,
+        elem->has_addl_path_id ? "_AP" : "", record->time_sec);
     break;
   case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
   case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
   case BGPSTREAM_ELEM_TYPE_PEERSTATE:
-    c = snprintf(buf_p, B_REMAIN, "BGP4MP|%" PRIu32, record->time_sec);
+    c = snprintf(buf_p, B_REMAIN, "BGP4MP%s|%" PRIu32,
+        elem->has_addl_path_id ? "_AP" : "", record->time_sec);
     break;
   default:
     c = 0;
@@ -131,6 +133,13 @@ char *bgpstream_record_elem_bgpdump_snprintf(char *buf, size_t len,
     }
     SEEK_STR_END;
     ADD_PIPE;
+
+    if (elem->has_addl_path_id) {
+      c = snprintf(buf_p, B_REMAIN, "%" PRIu32, elem->addl_path_id);
+      written += c;
+      buf_p += c;
+      ADD_PIPE;
+    }
 
     /* AS PATH */
     c = bgpstream_as_path_snprintf(buf_p, B_REMAIN, elem->as_path);

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -272,6 +272,11 @@ char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
       return NULL;
     }
     SEEK_STR_END;
+    if (elem->has_addl_path_id) {
+      c = snprintf(buf_p, B_REMAIN, "#%" PRIu32, elem->addl_path_id);
+      written += c;
+      buf_p += c;
+    }
     ADD_PIPE;
 
     /* NEXT HOP */

--- a/lib/bgpstream_elem.h
+++ b/lib/bgpstream_elem.h
@@ -203,6 +203,15 @@ typedef struct bgpstream_elem {
    */
   bgpstream_pfx_t prefix;
 
+  /** Additional Path Identifier (RFC 7911)
+   *
+   * Available only for RIB, Announcement and Withdrawal elem types
+   */
+  uint32_t addl_path_id;
+
+  /** Set if the addl_path_id field is valid */
+  uint8_t has_addl_path_id;
+
   /** Next hop
    *
    * Available only for RIB and Announcement elem types

--- a/lib/formats/bs_format_mrt.c
+++ b/lib/formats/bs_format_mrt.c
@@ -89,6 +89,8 @@ static int handle_table_dump(rec_data_t *rd, parsebgp_mrt_msg_t *mrt)
   el->type = BGPSTREAM_ELEM_TYPE_RIB;
   el->orig_time_sec = td->originated_time;
   el->orig_time_usec = 0;
+  el->has_addl_path_id = 0;
+  el->addl_path_id = 0;
 
   COPY_IP(&el->peer_ip, mrt->subtype, &td->peer_ip, return -1);
 
@@ -122,6 +124,8 @@ static int handle_td2_rib_entry(rec_data_t *rd, khash_t(td2_peer) * peer_table,
 
   rd->elem->orig_time_sec = re->originated_time;
   rd->elem->orig_time_usec = 0;
+  rd->elem->has_addl_path_id = re->has_addl_path_id;
+  rd->elem->addl_path_id = re->addl_path_id;
 
   // look the peer up in the peer index table
   if ((k = kh_get(td2_peer, peer_table, re->peer_index)) ==
@@ -202,9 +206,11 @@ static int handle_table_dump_v2(rec_data_t *rd, khash_t(td2_peer) * peer_table,
     break;
 
   case PARSEBGP_MRT_TABLE_DUMP_V2_RIB_IPV4_UNICAST:
+  case PARSEBGP_MRT_TABLE_DUMP_V2_RIB_IPV4_UNICAST_ADDPATH:
     return handle_td2_afi_safi_rib(rd, peer_table, mrt, PARSEBGP_BGP_AFI_IPV4,
                                    &td2->afi_safi_rib);
   case PARSEBGP_MRT_TABLE_DUMP_V2_RIB_IPV6_UNICAST:
+  case PARSEBGP_MRT_TABLE_DUMP_V2_RIB_IPV6_UNICAST_ADDPATH:
     return handle_td2_afi_safi_rib(rd, peer_table, mrt, PARSEBGP_BGP_AFI_IPV6,
                                    &td2->afi_safi_rib);
 

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -62,8 +62,8 @@
   "# Elem format:\n"                                                           \
   "# "                                                                         \
   "<rec-type>|<elem-type>|<rec-ts-sec>.<rec-ts-usec>|<project>|<collector>|<"  \
-  "router>|<router-ip>|<peer-ASN>|<peer-IP>|<prefix>|<next-hop-IP>|<AS-path>|" \
-  "<origin-AS>|<communities>|<old-state>|<new-state>\n"                        \
+  "router>|<router-ip>|<peer-ASN>|<peer-IP>|<prefix>[#<path_id>]|<next-hop-IP>"\
+  "|<AS-path>|<origin-AS>|<communities>|<old-state>|<new-state>\n"             \
   "#\n"                                                                        \
   "# <rec-type>: R RIB, U Update\n"                                            \
   "# <elem-type>: R RIB, A announcement, W withdrawal, S state message\n"      \


### PR DESCRIPTION
Depends on https://github.com/CAIDA/libparsebgp/pull/82
Fixes https://github.com/CAIDA/libparsebgp/issues/76

There were several options for how to format the new addtional path id field in bgpreader -e output.  Keep in mind, the idea behind the additional path feature is that multiple AS paths can coexist for a given prefix (from the same peer); i.e., a received path should not replace a path received earlier for the same prefix but with a different path id.

In bgpdump -m output, the new additional path id field appears as a new column in a record with a new TABLE_DUMP2_AP type.  Here's the bgpdump output for a traditional record (for comparison) and a new AP record:

```
TABLE_DUMP2|1576051200|B|185.19.140.105|198349|1.0.0.0/24|198349 1267 13335|IGP|185.19.140.105|0|0|1267:180 1267:200|NAG|13335 172.68.196.1|
TABLE_DUMP2_AP|1576051200|B|185.36.140.18|47950|1.0.0.0/24|100|47950 1299 13335|IGP|185.36.140.18|0|0|1299:30000|NAG|13335 162.158.84.1|
```

They added the path_identifier field "100" after the prefix.  That was easy enough to emulate in bgpreader -m.

Here are the same two records in bgpreader -e format, without the new path_identifier field:

```
# <rec-type>|<elem-type>|<rec-ts-sec>.<rec-ts-usec>|<project>|<collector>|<router>|<router-ip>|<peer-ASN>|<peer-IP>|<prefix>|<next-hop-IP>|<AS-path>|<origin-AS>|<communities>|<old-state>|<new-state>
#
# <rec-type>: R RIB, U Update
# <elem-type>: R RIB, A announcement, W withdrawal, S state message
#
R|R|1576051200.000000|singlefile|singlefile|||198349|185.19.140.105|1.0.0.0/24|185.19.140.105|198349 1267 13335|13335|1267:180 1267:200||
R|R|1576051200.000000|singlefile|singlefile|||47950|185.36.140.18|1.0.0.0/24|185.36.140.18|47950 1299 13335|13335|1299:30000||
```

* Option 0: add a new path id column after prefix.
  Pro: this is the most obvious option.  Authors of all existing code would be forced to consider if/how to deal with the new path id field.
  Con: it breaks all existing code that parses bgpreader output, even if that code did not need to break, i.e. the code did not care about prefixes.

* Option 1: add a new column to the end of each elem line.
  Pro: Doesn't break code that doesn't care about prefix (e.g., just accumulating all possible paths or AS adjacencies) if it just ignores the extra column.
  Con: Silently produces bad results in code that does care about prefix if it just ignores extra column.

* Option 2: similar to bgpdump: add a new elem-type, with a new column. E.g., appending "a" to the elem-type indicates that there's a new additional path id column after the prefix:
  ```
  R|Ra|1576051200.000000|singlefile|singlefile|||47950|185.36.140.18|1.0.0.0/24|100|185.36.140.18|47950 1299 13335|13335|1299:30000||
  ```
  Pro: wouldn't break existing code if it ignores elems with the unknown type.  If that code cares about prefixes, it would ignore those elems, but at least it wouldn't produce invalid results.
  Con: would break existing code that rejects the unknown elem type, even if that code didn't care about prefixes.

* Option 3:  add path id as a sub-field to prefix, e.g. separated by "#":
  ```
  R|R|1576051200.000000|singlefile|singlefile|||47950|185.36.140.18|1.0.0.0/24#100|185.36.140.18|47950 1299 13335|13335|1299:30000||
  ```
  Pro: wouldn't break code that doesn't look at prefix.  Code that does care about prefix will be forced to consider if/how to deal with the new path id field.
  Con: awkward format

In all cases, code that doesn't care about prefixes could be easily modified to ignore the new path id field, so breaking that code isn't really that big of a deal.

I implemented option 3, although now I'm thinking option 0 might be better.  @mingwei, @alistair, what's your opinion?