### PR TITLE
Kafka transport performance improvements

### DIFF
--- a/lib/bgpstream_resource_mgr.c
+++ b/lib/bgpstream_resource_mgr.c
@@ -40,7 +40,7 @@
 
 /** Approximately how frequently should stream resources that return AGAIN be
     polled? (in msec) */
-#define AGAIN_POLL_INTERVAL 500
+#define AGAIN_POLL_INTERVAL 100
 #define MSEC_TO_NSEC 1000000
 
 struct res_list_elem {

--- a/lib/transports/bs_transport_kafka.c
+++ b/lib/transports/bs_transport_kafka.c
@@ -36,7 +36,7 @@
 
 #define STATE ((state_t *)(transport->state))
 
-#define POLL_TIMEOUT_MSEC 0
+#define POLL_TIMEOUT_MSEC 500
 
 typedef struct state {
 


### PR DESCRIPTION
Reduce fetch batch sizes and timers to reduce latency and improve kafka performance -- especially for distant or low-bandwidth consumers.

Also tweaks the resource manager poll interval. This might cost a bit more CPU time in cases where we're consuming stream resources that often return EOF, but IMO it's worth the tradeoff -- we could even consider reducing this further. I've offset this by allowing the Kafka transport to block for 500ms when polling for new data from Kafka.