### PR TITLE
kafka: prefer roundrobin rebalance strategy

### DIFF
--- a/lib/transports/bs_transport_kafka.c
+++ b/lib/transports/bs_transport_kafka.c
@@ -201,6 +201,15 @@ static int init_kafka_config(bgpstream_transport_t *transport,
     return -1;
   }
 
+  // We don't want to use range rebalance strategy since often our
+  // topics only have one partition.
+  // TODO: use an incremental strategy and allow group.instance.id to be set.
+  if (rd_kafka_conf_set(conf, "partition.assignment.strategy", "roundrobin", errstr,
+                        sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+    bgpstream_log(BGPSTREAM_LOG_ERR, "Config Error: %s", errstr);
+    return -1;
+  }
+
 #ifdef DEBUG
   if (rd_kafka_conf_set(conf, "debug", "broker", errstr,
                         sizeof(errstr)) != RD_KAFKA_CONF_OK) {


### PR DESCRIPTION
By default librdkafka uses the "range" strategy which (from what I understand), given two consumers C1 and C2, and four topic/partitions A0,A1,B0,B1 will assign them as C1:{A0,B0}, C2:{A1,B1}. This is nice when your topics have multiple partitions (the normal case), but OpenBMP uses topics with a single partition to preserve message ordering and so the range strategy with two consumers and two topics A0,B0 will assign them both C1 and leave C2 with nothing (as soon as C1 shuts down then C2 will get the full set of topics).

Instead we want all partitions to be evenly distributed across consumers which is what the round-robin strategy does.

Eventually we'd probably want a cooperative strategy that only changes assignments incrementally (to avoid massive rebalances when there are many consumers), and we want to use the new static consumer groups feature in Kafka 2.3+, but this is good enough for now.