### PR TITLE
Ensure we move past an invalid message

### DIFF
--- a/lib/formats/bgpstream_parsebgp_common.c
+++ b/lib/formats/bgpstream_parsebgp_common.c
@@ -606,6 +606,10 @@ refill:
     fclose(fp);
 #endif
 
+    // move past this record in our buffer
+    state->ptr += dec_len;
+    state->remain -= dec_len;
+
     record->status = BGPSTREAM_RECORD_STATUS_CORRUPTED_RECORD;
     return BGPSTREAM_FORMAT_CORRUPTED_DUMP;
   }


### PR DESCRIPTION
Previously we would return an invalid record message, but not move past
it in the buffer, so the next call would re-parse the same (still
invalid) message and get stuck in a loop of bad.