### PR TITLE
Downgrade parsebgp invalid message log to warning

### DIFF
--- a/lib/formats/bgpstream_parsebgp_common.c
+++ b/lib/formats/bgpstream_parsebgp_common.c
@@ -595,7 +595,7 @@ refill:
       refill = 1;
       goto refill;
     }
-    // else: its a fatal error
+    // else: its an invalid message
     bgpstream_log(BGPSTREAM_LOG_WARN,
                   "Failed to parse message from '%s' (%d:%s)", format->res->url,
                   err, parsebgp_strerror(err));
@@ -611,7 +611,7 @@ refill:
     state->remain -= dec_len;
 
     record->status = BGPSTREAM_RECORD_STATUS_CORRUPTED_RECORD;
-    return BGPSTREAM_FORMAT_CORRUPTED_DUMP;
+    return BGPSTREAM_FORMAT_CORRUPTED_MSG;
   }
   // else: successful read
   state->ptr += dec_len;

--- a/lib/formats/bgpstream_parsebgp_common.c
+++ b/lib/formats/bgpstream_parsebgp_common.c
@@ -596,7 +596,7 @@ refill:
       goto refill;
     }
     // else: its a fatal error
-    bgpstream_log(BGPSTREAM_LOG_ERR,
+    bgpstream_log(BGPSTREAM_LOG_WARN,
                   "Failed to parse message from '%s' (%d:%s)", format->res->url,
                   err, parsebgp_strerror(err));
 

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -670,10 +670,6 @@ int main(int argc, char *argv[])
          (rrc = bgpstream_get_next_record(bs, &bs_record)) > 0) {
     rec_cnt++;
 
-    if (bs_record->status != BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
-      continue;
-    }
-
     if (record_output_on && print_record(bs_record) != 0) {
       goto done;
     }


### PR DESCRIPTION
We're already returning a corrupted record message in-band (just a few lines after this log), so there's no need for an error-level log. Even a warning log is probably even overkill.

In general it would be nice to have a mechanism for passing "error" messages to the user without just spewing them to stderr. librdkafka has something like this where one can register an error callback and then the user can decide what they want to do with the messages.

But in the short term, let's find cases like this where we can downgrade (or even remove) logs so that we reserve error-level messages for when things have really gone wrong _and_ we can't communicate that information in-band?