### PR TITLE
Avoid inserting /0s into the prefix patricia trie

### DIFF
--- a/lib/utils/bgpstream_utils_patricia.c
+++ b/lib/utils/bgpstream_utils_patricia.c
@@ -660,10 +660,17 @@ bgpstream_patricia_tree_insert(bgpstream_patricia_tree_t *pt,
   /* Find insertion point */
   int relation;
   uint8_t differ_bit;
+  uint8_t bitlen = pfx->mask_len;
+
+  /* Avoid inserting /0s -- they don't make sense and tend to confuse
+   * matters.
+   */
+  if (bitlen == 0) {
+    return NULL;
+  }
 
   node_it = bpt_find_insert_point(node_it, pfx, &relation, &differ_bit);
 
-  uint8_t bitlen = pfx->mask_len;
   if (relation == BGPSTREAM_PATRICIA_SELF) {
     /* check the node contains an actual prefix,
      * i.e. it is not a glue node */


### PR DESCRIPTION
The main reason to avoid this is because it will run the risk
of triggering an assertion:

    assert(bgpstream_pfx_equal(&node_it->prefix, pfx));

The problem is that any lookup for the insertion point for a
/0 prefix is going to return the tree head (for v6, ::/0)
immediately -- but if we are for some reason trying to insert
100::6:6:6/0 then the assertion is going to fail because the
two prefixes are not considered equal.

Of course, the real question is why one would
try and insert /0 prefixes in the first place -- these bogus
prefixes are not coming from our collectors directly, so some
bug within the bgpstream consumer (specifically
per-geo-visibility in the cases that I have observed) is causing
these /0 prefixes to come about...