### PR TITLE
added -J option to exclude collector peers by ASN

### DIFF
--- a/lib/bgpstream.h.in
+++ b/lib/bgpstream.h.in
@@ -92,6 +92,9 @@ typedef enum {
   /** Filter records based on record type (e.g. 'updates') */
   BGPSTREAM_FILTER_TYPE_RECORD_TYPE,
 
+  /** Filter elems based on not peer ASN  */
+  BGPSTREAM_FILTER_TYPE_ELEM_NOT_PEER_ASN,
+
   /** Filter elems based on peer ASN  */
   BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN,
 

--- a/lib/bgpstream_filter.c
+++ b/lib/bgpstream_filter.c
@@ -96,6 +96,15 @@ int bgpstream_filter_mgr_filter_add(bgpstream_filter_mgr_t *this,
     }
     return bsf_id_set_insert(&this->peer_asns, (uint32_t)ul);
 
+  case BGPSTREAM_FILTER_TYPE_ELEM_NOT_PEER_ASN:
+    errno = 0;
+    ul = strtoul(filter_value, &endp, 10);
+    if (errno || ul > UINT32_MAX || *endp) {
+      bgpstream_log(BGPSTREAM_LOG_ERR, "invalid not peer asn '%s'", filter_value);
+      return 0;
+    }
+    return bsf_id_set_insert(&this->not_peer_asns, (uint32_t)ul);
+
   case BGPSTREAM_FILTER_TYPE_ELEM_ORIGIN_ASN:
     errno = 0;
     ul = strtoul(filter_value, &endp, 10);
@@ -415,6 +424,10 @@ void bgpstream_filter_mgr_destroy(bgpstream_filter_mgr_t *this)
   // peer asns
   if (this->peer_asns != NULL) {
     bgpstream_id_set_destroy(this->peer_asns);
+  }
+  // not peer asns
+  if (this->not_peer_asns != NULL) {
+    bgpstream_id_set_destroy(this->not_peer_asns);
   }
   // origin asns
   if (this->origin_asns != NULL) {

--- a/lib/bgpstream_filter.h
+++ b/lib/bgpstream_filter.h
@@ -73,6 +73,7 @@ typedef struct struct_bgpstream_filter_mgr_t {
   int aspath_expr_cnt;
   int aspath_expr_alloc_cnt;
   bgpstream_id_set_t *peer_asns;
+  bgpstream_id_set_t *not_peer_asns;
   bgpstream_id_set_t *origin_asns;
   bgpstream_patricia_tree_t *prefixes;
   bgpstream_community_filter_t *communities;

--- a/lib/bgpstream_filter_parser.c
+++ b/lib/bgpstream_filter_parser.c
@@ -44,6 +44,8 @@ static const char *bgpstream_filter_type_to_string(bgpstream_filter_type_t type)
     return "Prefix (or more specific)";
   case BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY:
     return "Community";
+  case BGPSTREAM_FILTER_TYPE_ELEM_NOT_PEER_ASN:
+    return "Not Peer ASN";
   case BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN:
     return "Peer ASN";
   case BGPSTREAM_FILTER_TYPE_ELEM_ORIGIN_ASN:
@@ -89,6 +91,7 @@ static int instantiate_filter(bgpstream_t *bs, bgpstream_filter_item_t *item)
   case BGPSTREAM_FILTER_TYPE_ELEM_PREFIX_EXACT:
   case BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY:
   case BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN:
+  case BGPSTREAM_FILTER_TYPE_ELEM_NOT_PEER_ASN:
   case BGPSTREAM_FILTER_TYPE_ELEM_ORIGIN_ASN:
   case BGPSTREAM_FILTER_TYPE_PROJECT:
   case BGPSTREAM_FILTER_TYPE_COLLECTOR:

--- a/lib/bgpstream_record.c
+++ b/lib/bgpstream_record.c
@@ -164,6 +164,13 @@ static int elem_check_filters(bgpstream_record_t *record,
     return 0;
   }
 
+  /* Checking not peer ASNs: if the filter is on and the peer asn is in the
+  * set, return 0 */
+  if (filter_mgr->not_peer_asns &&
+      bgpstream_id_set_exists(filter_mgr->not_peer_asns, elem->peer_asn) == 1) {
+    return 0;
+  }
+
   /* Checking origin ASN */
   if (filter_mgr->origin_asns) {
     if (elem->type == BGPSTREAM_ELEM_TYPE_WITHDRAWAL ||

--- a/lib/datainterfaces/bsdi_broker.c
+++ b/lib/datainterfaces/bsdi_broker.c
@@ -696,20 +696,6 @@ static int update_query_url(bsdi_t *di)
       APPEND_STR(f);
     }
   }
-  // not peer asns
-  uint32_t *np;
-  char np_buf[sizeof(STR(UINT32_MAX))+1];
-  if (filter_mgr->not_peer_asns != NULL) {
-    bgpstream_id_set_rewind(filter_mgr->not_peer_asns);
-    while ((np = bgpstream_id_set_next(filter_mgr->not_peer_asns)) != NULL) {
-      if (snprintf(np_buf, sizeof(np_buf), "%"PRIu32, *np) >= sizeof(np_buf)) {
-        goto err;
-      }
-      AMPORQ;
-      APPEND_STR("not_peer_asns[]=");
-      APPEND_STR(np_buf);
-    }
-  }
   // peer asns
   uint32_t *p;
   char p_buf[sizeof(STR(UINT32_MAX))+1];

--- a/lib/datainterfaces/bsdi_broker.c
+++ b/lib/datainterfaces/bsdi_broker.c
@@ -696,6 +696,20 @@ static int update_query_url(bsdi_t *di)
       APPEND_STR(f);
     }
   }
+  // not peer asns
+  uint32_t *np;
+  char np_buf[sizeof(STR(UINT32_MAX))+1];
+  if (filter_mgr->not_peer_asns != NULL) {
+    bgpstream_id_set_rewind(filter_mgr->not_peer_asns);
+    while ((np = bgpstream_id_set_next(filter_mgr->not_peer_asns)) != NULL) {
+      if (snprintf(np_buf, sizeof(np_buf), "%"PRIu32, *np) >= sizeof(np_buf)) {
+        goto err;
+      }
+      AMPORQ;
+      APPEND_STR("not_peer_asns[]=");
+      APPEND_STR(np_buf);
+    }
+  }
   // peer asns
   uint32_t *p;
   char p_buf[sizeof(STR(UINT32_MAX))+1];

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -129,7 +129,7 @@ static struct bs_options_t bs_opts[] =
   {{"peer-asn", required_argument, 0, 'j'},
    "<peer ASN>",
    "return elems received by a given peer ASN*"},
-  {{"peer-asn", required_argument, 0, 'J'},
+  {{"not-peer-asn", required_argument, 0, 'J'},
    "<not peer ASN>",
    "exclude elems received by a given peer ASN*"},
   {{"origin-asn", required_argument, 0, 'a'},

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -129,6 +129,9 @@ static struct bs_options_t bs_opts[] =
   {{"peer-asn", required_argument, 0, 'j'},
    "<peer ASN>",
    "return elems received by a given peer ASN*"},
+  {{"peer-asn", required_argument, 0, 'J'},
+   "<not peer ASN>",
+   "exclude elems received by a given peer ASN*"},
   {{"origin-asn", required_argument, 0, 'a'},
    "<origin ASN>",
    "return elems originated by a given origin ASN*"},
@@ -423,6 +426,8 @@ int main(int argc, char *argv[])
     PARSE_FILTER_OPTION('R', BGPSTREAM_FILTER_TYPE_ROUTER)
       break;
     PARSE_FILTER_OPTION('j', BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN)
+      break;
+    PARSE_FILTER_OPTION('J', BGPSTREAM_FILTER_TYPE_ELEM_NOT_PEER_ASN)
       break;
     PARSE_FILTER_OPTION('a', BGPSTREAM_FILTER_TYPE_ELEM_ORIGIN_ASN)
       break;


### PR DESCRIPTION
This filter allows the user to exclude collector peers specified by their ASN 